### PR TITLE
feat(channels): add markdown-to-HTML conversion for Campfire messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "google-auth-oauthlib>=1.0.0",
     "google-api-python-client>=2.0.0",
     "aiohttp>=3.9.0",  # Campfire adapter (webhook server)
+    "markdown>=3.5.0",  # Markdown to HTML conversion (for Campfire)
 ]
 
 [project.optional-dependencies]

--- a/src/openpaws/channels/campfire.py
+++ b/src/openpaws/channels/campfire.py
@@ -27,6 +27,7 @@ Note: Reading conversation context requires the bot read API (PR #190).
 """
 
 import asyncio
+import html
 import logging
 import re
 from dataclasses import dataclass, replace
@@ -399,10 +400,17 @@ class CampfireAdapter(ChannelAdapter):
             raise RuntimeError(f"Campfire API error: {resp.status}")
 
     def _markdown_to_html(self, text: str) -> str:
-        """Convert markdown text to HTML for Campfire's ActionText rendering."""
-        # Use fenced_code and tables extensions for better formatting
+        """Convert markdown text to HTML for Campfire's ActionText rendering.
+
+        Security: Escapes any raw HTML in the input to prevent XSS attacks.
+        The markdown library doesn't sanitize HTML by default, so we escape
+        HTML entities before conversion to ensure script tags and other
+        potentially dangerous HTML cannot be injected.
+        """
+        # Escape HTML to prevent XSS attacks before markdown conversion
+        safe_text = html.escape(text)
         return markdown.markdown(
-            text,
+            safe_text,
             extensions=["fenced_code", "tables", "nl2br"],
         )
 

--- a/src/openpaws/channels/campfire.py
+++ b/src/openpaws/channels/campfire.py
@@ -31,6 +31,7 @@ import logging
 import re
 from dataclasses import dataclass, replace
 
+import markdown
 from aiohttp import ClientSession, web
 
 from openpaws.channels.base import (
@@ -397,14 +398,27 @@ class CampfireAdapter(ChannelAdapter):
             logger.error(f"Failed to send message: {resp.status} - {body}")
             raise RuntimeError(f"Campfire API error: {resp.status}")
 
+    def _markdown_to_html(self, text: str) -> str:
+        """Convert markdown text to HTML for Campfire's ActionText rendering."""
+        # Use fenced_code and tables extensions for better formatting
+        return markdown.markdown(
+            text,
+            extensions=["fenced_code", "tables", "nl2br"],
+        )
+
     async def send_message(self, message: OutgoingMessage) -> None:
-        """Send a message to a Campfire room."""
+        """Send a message to a Campfire room.
+
+        Converts markdown to HTML before sending since Campfire uses ActionText
+        which renders HTML but not markdown.
+        """
         if not self._http_session:
             raise RuntimeError("Campfire adapter not started")
         url = self._build_message_url(message.channel_id)
-        headers = {"Content-Type": "text/plain; charset=utf-8"}
+        html_content = self._markdown_to_html(message.text)
+        headers = {"Content-Type": "text/html; charset=utf-8"}
         async with self._http_session.post(
-            url, data=message.text, headers=headers
+            url, data=html_content, headers=headers
         ) as resp:
             await self._handle_send_response(resp, message.channel_id)
 

--- a/tests/test_campfire_adapter.py
+++ b/tests/test_campfire_adapter.py
@@ -630,6 +630,22 @@ class TestCampfireMarkdownToHtml:
         assert "<table>" in result
         assert "<th>" in result or "<td>" in result
 
+    def test_html_injection_is_escaped(self, adapter):
+        """Raw HTML and script tags are escaped to prevent XSS attacks."""
+        dangerous_input = "Hello <script>alert('xss')</script> world"
+        result = adapter._markdown_to_html(dangerous_input)
+        # Script tag should be escaped, not executable
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_html_tags_are_escaped(self, adapter):
+        """All HTML tags in user input are escaped."""
+        input_with_html = "Check out <a href='evil.com'>this link</a>!"
+        result = adapter._markdown_to_html(input_with_html)
+        # Raw HTML tags should be escaped
+        assert "<a href=" not in result
+        assert "&lt;a href=" in result
+
 
 class TestCampfireAdapterSendMessage:
     """Tests for Campfire adapter send_message."""

--- a/tests/test_campfire_adapter.py
+++ b/tests/test_campfire_adapter.py
@@ -579,6 +579,58 @@ class TestCampfireAdapterLifecycle:
         assert adapter.is_running() is False
 
 
+class TestCampfireMarkdownToHtml:
+    """Tests for markdown to HTML conversion."""
+
+    @pytest.fixture
+    def adapter(self):
+        """Create an adapter for testing."""
+        config = CampfireConfig(
+            base_url="https://chat.example.com",
+            bot_key="123-abc",
+        )
+        return CampfireAdapter(config)
+
+    def test_plain_text_becomes_paragraph(self, adapter):
+        """Plain text is wrapped in paragraph tags."""
+        result = adapter._markdown_to_html("Hello world")
+        assert result == "<p>Hello world</p>"
+
+    def test_bold_text(self, adapter):
+        """Bold markdown is converted to strong tags."""
+        result = adapter._markdown_to_html("This is **bold** text")
+        assert "<strong>bold</strong>" in result
+
+    def test_italic_text(self, adapter):
+        """Italic markdown is converted to em tags."""
+        result = adapter._markdown_to_html("This is *italic* text")
+        assert "<em>italic</em>" in result
+
+    def test_code_block(self, adapter):
+        """Fenced code blocks are converted properly."""
+        result = adapter._markdown_to_html("```python\nprint('hello')\n```")
+        assert "<pre>" in result
+        assert "<code" in result  # Has class attribute: <code class="language-python">
+        assert "print" in result
+
+    def test_inline_code(self, adapter):
+        """Inline code is converted to code tags."""
+        result = adapter._markdown_to_html("Use `print()` function")
+        assert "<code>print()</code>" in result
+
+    def test_newlines_become_breaks(self, adapter):
+        """Newlines are converted to br tags via nl2br extension."""
+        result = adapter._markdown_to_html("Line one\nLine two")
+        assert "<br" in result
+
+    def test_table_formatting(self, adapter):
+        """Tables are converted properly via tables extension."""
+        md = "| Header |\n|--------|\n| Cell   |"
+        result = adapter._markdown_to_html(md)
+        assert "<table>" in result
+        assert "<th>" in result or "<td>" in result
+
+
 class TestCampfireAdapterSendMessage:
     """Tests for Campfire adapter send_message."""
 
@@ -592,7 +644,11 @@ class TestCampfireAdapterSendMessage:
 
     @pytest.mark.asyncio
     async def test_send_message_success(self, config):
-        """Test sending a message successfully."""
+        """Test sending a message successfully.
+
+        Messages are converted from markdown to HTML before sending since
+        Campfire uses ActionText which renders HTML but not markdown.
+        """
         adapter = CampfireAdapter(config)
 
         mock_response = AsyncMock()
@@ -612,10 +668,11 @@ class TestCampfireAdapterSendMessage:
 
         await adapter.send_message(msg)
 
+        # Markdown converts plain text to HTML paragraphs
         mock_session.post.assert_called_once_with(
             "https://chat.example.com/rooms/1/123-abc/messages",
-            data="Hello from bot!",
-            headers={"Content-Type": "text/plain; charset=utf-8"},
+            data="<p>Hello from bot!</p>",
+            headers={"Content-Type": "text/html; charset=utf-8"},
         )
 
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1860,6 +1860,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2197,6 +2206,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
+    { name = "markdown" },
     { name = "openhands-sdk" },
     { name = "openhands-tools" },
     { name = "python-telegram-bot" },
@@ -2224,6 +2234,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
+    { name = "markdown", specifier = ">=3.5.0" },
     { name = "openhands-sdk", specifier = ">=1.0.0" },
     { name = "openhands-tools", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary

Campfire uses ActionText which renders HTML but not markdown. This PR adds automatic conversion of outgoing messages from markdown to HTML before sending to Campfire.

## Changes

- **New dependency**: Added `markdown>=3.5.0` to `pyproject.toml`
- **Markdown conversion**: Added `_markdown_to_html()` method to `CampfireAdapter`
- **HTML output**: Changed `send_message()` to convert markdown and send as `text/html`
- **Extensions enabled**:
  - `fenced_code`: Proper code block rendering with syntax highlighting class
  - `tables`: Markdown table support
  - `nl2br`: Newlines converted to `<br>` tags for better formatting
- **Tests**: Added comprehensive test coverage for the markdown conversion functionality

## Testing

- All 461 tests pass
- New tests cover: plain text, bold, italic, code blocks, inline code, newlines, and tables

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*