### PR TITLE
fix: correct message ordering and remove aggressive context truncation

### DIFF
--- a/src/openpaws/channels/campfire.py
+++ b/src/openpaws/channels/campfire.py
@@ -46,16 +46,16 @@ logger = logging.getLogger(__name__)
 ROOM_PATH_PATTERN = re.compile(r"/rooms/(\d+)/")
 
 # Default number of recent messages to include for context
-DEFAULT_CONTEXT_MESSAGES = 10
+DEFAULT_CONTEXT_MESSAGES = 20
 
+# Hard cap on context messages to prevent excessive token usage
+# 100 messages with 2 paragraphs each ≈ 23K tokens, well within modern LLM limits
+# Use context_messages config setting to control context size per deployment
+MAX_CONTEXT_MESSAGES = 100
 
 # Default webhook host - 127.0.0.1 for security (local only)
 # Use "0.0.0.0" when running in Docker and receiving webhooks from host
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
-
-# Maximum characters for conversation context to avoid LLM token limits
-# Roughly ~1000 tokens, leaving room for the actual message
-MAX_CONTEXT_CHARS = 4000
 
 
 @dataclass
@@ -352,8 +352,10 @@ class CampfireAdapter(ChannelAdapter):
         messages = await self._fetch_messages_from_api(url, params)
         if messages is None:
             return []
-        # API returns newest-first; take last N and reverse to chronological order
-        limited = messages[-self._config.context_messages :]
+        # Apply hard cap, then take configured amount
+        limit = min(self._config.context_messages, MAX_CONTEXT_MESSAGES)
+        # API returns newest-first; take first N (most recent) then reverse
+        limited = messages[:limit]
         return list(reversed(limited))
 
     def _format_single_context_message(self, msg: dict) -> str:
@@ -365,16 +367,6 @@ class CampfireAdapter(ChannelAdapter):
         text = msg.get("body", {}).get("plain", "")
         return f"**{name}**: {text}"
 
-    def _truncate_context_if_needed(self, context_text: str) -> str:
-        """Truncate context if it exceeds maximum length to avoid LLM token limits."""
-        if len(context_text) <= MAX_CONTEXT_CHARS:
-            return context_text
-        logger.warning(
-            f"Context truncated from {len(context_text)} to {MAX_CONTEXT_CHARS} chars"
-        )
-        # Keep the most recent part of the context (end of string)
-        return "...[earlier context truncated]...\n" + context_text[-MAX_CONTEXT_CHARS:]
-
     def _format_context_for_prompt(
         self, messages: list[dict], current_user: str
     ) -> str:
@@ -384,8 +376,7 @@ class CampfireAdapter(ChannelAdapter):
         header = "Here is the recent conversation context from this chat room:\n"
         body = "\n".join(self._format_single_context_message(m) for m in messages)
         footer = f"\n\n---\nNow {current_user} says:\n"
-        full_context = f"{header}\n{body}{footer}"
-        return self._truncate_context_if_needed(full_context)
+        return f"{header}\n{body}{footer}"
 
     async def _handle_send_response(self, resp, channel_id: str) -> None:
         """Handle response from message send API."""

--- a/src/openpaws/channels/campfire.py
+++ b/src/openpaws/channels/campfire.py
@@ -337,6 +337,15 @@ class CampfireAdapter(ChannelAdapter):
             logger.warning(f"Could not fetch room context: {e}")
         return None
 
+    def _get_context_limit(self) -> int:
+        """Get context message limit, applying hard cap and logging if needed."""
+        if self._config.context_messages > MAX_CONTEXT_MESSAGES:
+            logger.warning(
+                f"Context messages capped at {MAX_CONTEXT_MESSAGES} "
+                f"(configured: {self._config.context_messages})"
+            )
+        return min(self._config.context_messages, MAX_CONTEXT_MESSAGES)
+
     async def fetch_room_context(
         self, room_id: str, before_message_id: str | None = None
     ) -> list[dict]:
@@ -352,15 +361,8 @@ class CampfireAdapter(ChannelAdapter):
         messages = await self._fetch_messages_from_api(url, params)
         if messages is None:
             return []
-        # Apply hard cap, then take configured amount
-        limit = min(self._config.context_messages, MAX_CONTEXT_MESSAGES)
-        if self._config.context_messages > MAX_CONTEXT_MESSAGES:
-            logger.warning(
-                f"Context messages capped at {MAX_CONTEXT_MESSAGES} "
-                f"(configured: {self._config.context_messages})"
-            )
         # API returns newest-first; take first N (most recent) then reverse
-        limited = messages[:limit]
+        limited = messages[: self._get_context_limit()]
         return list(reversed(limited))
 
     def _format_single_context_message(self, msg: dict) -> str:

--- a/src/openpaws/channels/campfire.py
+++ b/src/openpaws/channels/campfire.py
@@ -354,6 +354,11 @@ class CampfireAdapter(ChannelAdapter):
             return []
         # Apply hard cap, then take configured amount
         limit = min(self._config.context_messages, MAX_CONTEXT_MESSAGES)
+        if self._config.context_messages > MAX_CONTEXT_MESSAGES:
+            logger.warning(
+                f"Context messages capped at {MAX_CONTEXT_MESSAGES} "
+                f"(configured: {self._config.context_messages})"
+            )
         # API returns newest-first; take first N (most recent) then reverse
         limited = messages[:limit]
         return list(reversed(limited))

--- a/tests/test_campfire_adapter.py
+++ b/tests/test_campfire_adapter.py
@@ -8,6 +8,7 @@ from aiohttp import web
 
 from openpaws.channels.base import IncomingMessage, OutgoingMessage
 from openpaws.channels.campfire import (
+    MAX_CONTEXT_MESSAGES,
     CampfireAdapter,
     CampfireConfig,
     create_campfire_adapter,
@@ -859,7 +860,7 @@ class TestCampfireAdapterContext:
         """Test that we take the most recent N messages, not the oldest N.
 
         When API returns more messages than context_messages limit, we should
-        take the last N (most recent before the target) not the first N (oldest).
+        take the first N (most recent before the target) not the last N (oldest).
         """
         from aiohttp import ClientSession
 
@@ -893,12 +894,12 @@ class TestCampfireAdapterContext:
 
         messages = await adapter.fetch_room_context("1")
 
-        # Should get the 3 most recent (msg3, msg2, msg1 from API = last 3)
-        # Reversed to chronological order: msg1, msg2, msg3
+        # Should get the 3 most recent (msg5, msg4, msg3 from API = first 3)
+        # Reversed to chronological order: msg3, msg4, msg5
         assert len(messages) == 3
-        assert messages[0]["body"]["plain"] == "msg1"  # Oldest of the 3
-        assert messages[1]["body"]["plain"] == "msg2"
-        assert messages[2]["body"]["plain"] == "msg3"  # Most recent (before target)
+        assert messages[0]["body"]["plain"] == "msg3"  # Oldest of the 3
+        assert messages[1]["body"]["plain"] == "msg4"
+        assert messages[2]["body"]["plain"] == "msg5"  # Most recent (before target)
 
     @pytest.mark.asyncio
     async def test_fetch_room_context_404(self, adapter):
@@ -968,4 +969,42 @@ class TestCampfireAdapterContext:
             base_url="https://chat.example.com",
             bot_key="123-abc",
         )
-        assert config.context_messages == 10
+        assert config.context_messages == 20
+
+    @pytest.mark.asyncio
+    async def test_fetch_room_context_respects_hard_cap(self, config):
+        """Test that context is capped at MAX_CONTEXT_MESSAGES."""
+        from aiohttp import ClientSession
+
+        # Configure to want more than the hard cap
+        config.context_messages = MAX_CONTEXT_MESSAGES + 50
+        adapter = CampfireAdapter(config)
+
+        # API returns MAX_CONTEXT_MESSAGES + 10 messages
+        num_messages = MAX_CONTEXT_MESSAGES + 10
+        mock_messages = [
+            {"id": i, "body": {"plain": f"msg{i}"}, "creator": {"name": "A"}}
+            for i in range(num_messages, 0, -1)  # newest first
+        ]
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "room": {"id": 1, "name": "General"},
+                "messages": mock_messages,
+                "pagination": {},
+            }
+        )
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = None
+
+        adapter._http_session = MagicMock(spec=ClientSession)
+        adapter._http_session.get.return_value = mock_cm
+
+        messages = await adapter.fetch_room_context("1")
+
+        # Should be capped at MAX_CONTEXT_MESSAGES
+        assert len(messages) == MAX_CONTEXT_MESSAGES


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Campfire adapter's context message fetching and removes an overly aggressive character truncation limit.

## Bug Fixes

### Message Ordering (Critical)
The code was fetching the **oldest** N messages instead of the **most recent** N messages before the current message.

**Root cause:** The API returns messages in newest-first order, but the code used `messages[-N:]` which takes the *last* N elements (the oldest). 

**Fix:** Changed to `messages[:N]` to take the *first* N elements (the most recent).

### Context Truncation
Removed the `MAX_CONTEXT_CHARS = 4000` limit (~1000 tokens) which was far too aggressive for modern LLMs with 100K+ token context windows. This was causing valuable conversation context to be discarded unnecessarily.

## Improvements

- **Bumped default context from 10 to 20 messages** - More context helps the LLM understand the conversation better
- **Added MAX_CONTEXT_MESSAGES = 100 hard cap** - Safety guard (~23K tokens max, still well within modern LLM limits)
- The `context_messages` config setting remains the intended way to control context size per deployment

## Testing

- All 455 tests pass
- Coverage: 82% (above 80% threshold)
- Added new test for MAX_CONTEXT_MESSAGES hard cap
- Fixed existing test that had incorrect expectations

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*