### PR TITLE
feat: add queue-based dispatch for multi-conversation orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,19 +87,24 @@ See `docs/CAMPFIRE_SETUP.md` for detailed configuration instructions.
 
 ```
 src/openpaws/
-├── __init__.py      # Package version
-├── __main__.py      # Entry point for `python -m openpaws`
-├── cli.py           # Click CLI commands (start, stop, status, tasks)
-├── config.py        # YAML config parsing with env var expansion
-├── daemon.py        # Daemon process management (PID file, signals, logging)
-├── runner.py        # Conversation runner (integrates with software-agent-sdk)
-├── scheduler.py     # Cron-based task scheduling (with storage integration)
-├── storage.py       # SQLite state persistence for tasks and sessions
-└── channels/        # Chat platform adapters
+├── __init__.py        # Package version
+├── __main__.py        # Entry point for `python -m openpaws`
+├── cli.py             # Click CLI commands (start, stop, status, tasks, queue)
+├── config.py          # YAML config parsing with env var expansion
+├── daemon.py          # Daemon process management (PID file, signals, logging)
+├── queue_manager.py   # Queue manager for multi-conversation orchestration
+├── runner.py          # Conversation runner (integrates with software-agent-sdk)
+├── scheduler.py       # Cron-based task scheduling (with storage integration)
+├── storage.py         # SQLite state persistence for tasks, sessions, and queue
+├── channels/          # Chat platform adapters
+│   ├── __init__.py
+│   ├── base.py        # Abstract ChannelAdapter interface
+│   ├── campfire.py    # Campfire adapter (webhook-based)
+│   └── slack.py       # Slack adapter (Socket Mode)
+└── tools/             # Custom agent tools
     ├── __init__.py
-    ├── base.py      # Abstract ChannelAdapter interface
-    ├── campfire.py  # Campfire adapter (webhook-based)
-    └── slack.py     # Slack adapter (Socket Mode)
+    ├── queue_next.py  # QueueNextTool for agent queue access
+    └── send_status.py # SendStatusTool for status updates
 
 scripts/
 ├── check_coverage.py          # Coverage reporting helper
@@ -108,15 +113,17 @@ scripts/
 └── setup_campfire_openpaw.py  # Campfire + OpenPaws installation script
 
 tests/
-├── conftest.py              # Pytest config, subprocess coverage setup
-├── test_campfire_adapter.py # Campfire adapter tests
-├── test_config.py           # Config parsing tests
-├── test_daemon.py           # Unit tests for daemon module
-├── test_daemon_integration.py  # Integration tests (real process start/stop)
-├── test_runner.py           # Conversation runner tests
-├── test_scheduler.py        # Scheduler unit tests
-├── test_slack_adapter.py    # Slack adapter tests
-└── test_storage.py          # SQLite storage tests
+├── conftest.py                # Pytest config, subprocess coverage setup
+├── test_campfire_adapter.py   # Campfire adapter tests
+├── test_config.py             # Config parsing tests
+├── test_daemon.py             # Unit tests for daemon module
+├── test_daemon_integration.py # Integration tests (real process start/stop)
+├── test_queue_manager.py      # Queue manager tests
+├── test_queue_next_tool.py    # QueueNextTool tests
+├── test_runner.py             # Conversation runner tests
+├── test_scheduler.py          # Scheduler unit tests
+├── test_slack_adapter.py      # Slack adapter tests
+└── test_storage.py            # SQLite storage tests (including queue)
 ```
 
 ## Development Commands
@@ -272,9 +279,40 @@ tasks:
     schedule: "0 8 * * *"  # Cron syntax
     group: main
     prompt: "Summarize top AI news"
+
+queue:
+  enabled: true             # Enable queue dispatch (default: true)
+  heartbeat_interval: 300   # Seconds between queue processing (default: 300)
+  max_dispatch: 5           # Max items per heartbeat (default: 5)
 ```
 
 See [docs/SLACK_SETUP.md](docs/SLACK_SETUP.md) for complete Slack setup instructions.
+
+### Queue Dispatch
+
+OpenPaws supports multi-conversation orchestration through a queue-based dispatch system.
+Agents can queue follow-up conversations using the `QueueNextTool`, and the daemon
+processes queued items at configured intervals (heartbeat).
+
+**CLI Commands:**
+```bash
+openpaws queue list              # List queued conversations
+openpaws queue stats             # Show queue statistics
+openpaws queue add "prompt" -g main  # Manually queue a conversation
+openpaws queue clear -s completed    # Clear completed items
+```
+
+**How it works:**
+1. During a conversation, the agent can use `queue_next` tool to schedule follow-ups
+2. Items are stored in SQLite with priority and context
+3. The heartbeat loop processes pending items at configured intervals
+4. Each item becomes a new conversation with the specified group
+
+**Example agent usage:**
+```
+The agent uses queue_next(prompt="Validate changes", group_name="main", 
+                          context={"pr_url": "..."}, priority=5)
+```
 
 ## Testing Guidelines
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ OpenPaws turns the OpenHands SDK from "run an agent when I call it" into "have a
 **Features:**
 - 📅 **Scheduled Tasks** - Cron-based recurring tasks that post results to chat
 - 💬 **Chat Connectors** - Multiple platform adapters (see below)
+- 🔄 **Queue Dispatch** - Multi-conversation workflows with priority and context
 - 🔒 **Sandboxed Execution** - Runs agents in isolated environments
 - ⚡ **Minimal Config** - YAML config + small CLI
 
@@ -84,6 +85,11 @@ openpaws status             # Show status
 openpaws tasks list         # List scheduled tasks
 openpaws tasks run <name>   # Run a task now
 
+openpaws queue list         # List queued conversations
+openpaws queue stats        # Show queue statistics
+openpaws queue add "prompt" -g main  # Manually queue a conversation
+openpaws queue clear -s completed    # Clear completed items
+
 openpaws logs               # View logs
 ```
 
@@ -120,7 +126,27 @@ tasks:
 
 agent:
   model: anthropic/claude-sonnet-4-20250514
+
+queue:
+  enabled: true             # Enable queue dispatch (default: true)
+  heartbeat_interval: 300   # Seconds between processing (default: 300)
+  max_dispatch: 5           # Max items per heartbeat (default: 5)
 ```
+
+### Queue Dispatch
+
+Queue dispatch enables multi-conversation workflows where agents can schedule follow-up conversations. During execution, the agent can use the `queue_next` tool to queue additional work:
+
+```
+Agent uses: queue_next(prompt="Validate deployment", group_name="ops", 
+                       context={"pr_url": "..."}, priority=5)
+```
+
+The daemon processes queued items at the configured heartbeat interval, creating new conversations for each item. This enables:
+- **Multi-step workflows** that span multiple agent conversations
+- **Rate limiting** - controlled pacing to avoid API limits
+- **Priority processing** - higher priority items run first
+- **Context preservation** - pass data between conversations
 
 ### Conversation Context (Campfire)
 

--- a/src/openpaws/cli.py
+++ b/src/openpaws/cli.py
@@ -453,22 +453,16 @@ def queue():
     pass
 
 
+_STATUS_EMOJI = {"pending": "⏳", "processing": "🔄", "completed": "✅", "failed": "❌"}
+
+
 def _format_queue_item(item) -> None:
     """Print a single queue item row."""
-    status_emoji = {
-        "pending": "⏳",
-        "processing": "🔄",
-        "completed": "✅",
-        "failed": "❌",
-    }.get(item.status, "❓")
-
-    prompt_preview = item.prompt[:40] + "..." if len(item.prompt) > 40 else item.prompt
+    emoji = _STATUS_EMOJI.get(item.status, "❓")
+    prompt = item.prompt[:40] + "..." if len(item.prompt) > 40 else item.prompt
     created = item.created_at.strftime("%Y-%m-%d %H:%M") if item.created_at else "-"
-    click.echo(
-        f"  {status_emoji} {item.id[:8]}  "
-        f"p={item.priority}  {item.group_name:<10}  "
-        f"{created}  {prompt_preview}"
-    )
+    click.echo(f"  {emoji} {item.id[:8]}  p={item.priority}  {item.group_name:<10}")
+    click.echo(f"      {created}  {prompt}")
 
 
 @queue.command("list")
@@ -507,6 +501,21 @@ def queue_stats():
     click.echo(f"  Total:       {total:>6}")
 
 
+def _clear_all_queue_items(storage: Storage, yes: bool) -> int:
+    """Clear all queue items with confirmation."""
+    if not yes:
+        click.confirm("⚠️  This will delete ALL queue items. Continue?", abort=True)
+    statuses = ["pending", "processing", "completed", "failed"]
+    return sum(storage.clear_queue(status=s) for s in statuses)
+
+
+def _clear_queue_by_status(storage: Storage, status: str, yes: bool) -> int:
+    """Clear queue items by status with confirmation."""
+    if not yes:
+        click.confirm(f"Delete all '{status}' queue items?", abort=True)
+    return storage.clear_queue(status=status)
+
+
 @queue.command("clear")
 @click.option(
     "--status", "-s",
@@ -518,26 +527,20 @@ def queue_stats():
 def queue_clear(status, yes):
     """Clear queue items by status."""
     storage = Storage()
-
     if status == "all":
-        if not yes:
-            click.confirm(
-                "⚠️  This will delete ALL queue items. Continue?",
-                abort=True,
-            )
-        # Clear all statuses
-        deleted = 0
-        for s in ["pending", "processing", "completed", "failed"]:
-            deleted += storage.clear_queue(status=s)
+        deleted = _clear_all_queue_items(storage, yes)
     else:
-        if not yes:
-            click.confirm(
-                f"Delete all '{status}' queue items?",
-                abort=True,
-            )
-        deleted = storage.clear_queue(status=status)
-
+        deleted = _clear_queue_by_status(storage, status, yes)
     click.echo(f"🗑️  Deleted {deleted} queue item(s)")
+
+
+def _validate_group_exists(group: str) -> None:
+    """Validate group exists in config, abort if not."""
+    config = _get_config_or_empty()
+    if group not in config.groups:
+        click.echo(f"❌ Error: Group '{group}' not found", err=True)
+        click.echo(f"Available groups: {', '.join(config.groups.keys()) or '(none)'}")
+        raise click.Abort()
 
 
 @queue.command("add")
@@ -549,6 +552,7 @@ def queue_add(prompt, group, priority, workflow_id):
     """Manually add a conversation to the queue."""
     from openpaws.storage import QueueItem
 
+    _validate_group_exists(group)
     storage = Storage()
     item = QueueItem.create(
         prompt=prompt,

--- a/src/openpaws/cli.py
+++ b/src/openpaws/cli.py
@@ -518,7 +518,8 @@ def _clear_queue_by_status(storage: Storage, status: str, yes: bool) -> int:
 
 @queue.command("clear")
 @click.option(
-    "--status", "-s",
+    "--status",
+    "-s",
     type=click.Choice(["completed", "failed", "all"]),
     default="completed",
     help="Status to clear (default: completed)",

--- a/src/openpaws/cli.py
+++ b/src/openpaws/cli.py
@@ -448,6 +448,120 @@ def logs(group, task, lines, follow):
 
 
 @main.group()
+def queue():
+    """Manage the conversation queue."""
+    pass
+
+
+def _format_queue_item(item) -> None:
+    """Print a single queue item row."""
+    status_emoji = {
+        "pending": "⏳",
+        "processing": "🔄",
+        "completed": "✅",
+        "failed": "❌",
+    }.get(item.status, "❓")
+
+    prompt_preview = item.prompt[:40] + "..." if len(item.prompt) > 40 else item.prompt
+    created = item.created_at.strftime("%Y-%m-%d %H:%M") if item.created_at else "-"
+    click.echo(
+        f"  {status_emoji} {item.id[:8]}  "
+        f"p={item.priority}  {item.group_name:<10}  "
+        f"{created}  {prompt_preview}"
+    )
+
+
+@queue.command("list")
+@click.option("--status", "-s", help="Filter by status (pending/completed/failed)")
+@click.option("--limit", "-n", default=20, help="Maximum items to show")
+def queue_list(status, limit):
+    """List queued conversations."""
+    storage = Storage()
+    items = storage.list_queue(status=status, limit=limit)
+
+    if not items:
+        click.echo("📋 Queue is empty")
+        return
+
+    click.echo("📋 Conversation Queue")
+    click.echo("─" * 80)
+
+    for item in items:
+        _format_queue_item(item)
+
+
+@queue.command("stats")
+def queue_stats():
+    """Show queue statistics."""
+    storage = Storage()
+    stats = storage.get_queue_stats()
+
+    total = sum(stats.values())
+    click.echo("📊 Queue Statistics")
+    click.echo("─" * 40)
+    click.echo(f"  Pending:     {stats.get('pending', 0):>6}")
+    click.echo(f"  Processing:  {stats.get('processing', 0):>6}")
+    click.echo(f"  Completed:   {stats.get('completed', 0):>6}")
+    click.echo(f"  Failed:      {stats.get('failed', 0):>6}")
+    click.echo("─" * 40)
+    click.echo(f"  Total:       {total:>6}")
+
+
+@queue.command("clear")
+@click.option(
+    "--status", "-s",
+    type=click.Choice(["completed", "failed", "all"]),
+    default="completed",
+    help="Status to clear (default: completed)",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+def queue_clear(status, yes):
+    """Clear queue items by status."""
+    storage = Storage()
+
+    if status == "all":
+        if not yes:
+            click.confirm(
+                "⚠️  This will delete ALL queue items. Continue?",
+                abort=True,
+            )
+        # Clear all statuses
+        deleted = 0
+        for s in ["pending", "processing", "completed", "failed"]:
+            deleted += storage.clear_queue(status=s)
+    else:
+        if not yes:
+            click.confirm(
+                f"Delete all '{status}' queue items?",
+                abort=True,
+            )
+        deleted = storage.clear_queue(status=status)
+
+    click.echo(f"🗑️  Deleted {deleted} queue item(s)")
+
+
+@queue.command("add")
+@click.argument("prompt")
+@click.option("--group", "-g", required=True, help="Group name to run in")
+@click.option("--priority", "-p", default=0, help="Priority (higher = processed first)")
+@click.option("--workflow-id", "-w", help="Optional workflow ID")
+def queue_add(prompt, group, priority, workflow_id):
+    """Manually add a conversation to the queue."""
+    from openpaws.storage import QueueItem
+
+    storage = Storage()
+    item = QueueItem.create(
+        prompt=prompt,
+        group_name=group,
+        priority=priority,
+        workflow_id=workflow_id,
+    )
+    storage.enqueue(item)
+    click.echo(f"✅ Queued conversation: {item.id[:8]}...")
+    click.echo(f"   Group: {group}, Priority: {priority}")
+
+
+@main.group()
 def setup():
     """Setup wizards for channels and integrations."""
     pass

--- a/src/openpaws/config.py
+++ b/src/openpaws/config.py
@@ -75,6 +75,19 @@ class AgentConfig:
 
 
 @dataclass
+class QueueConfig:
+    """Configuration for the queue-based dispatch system.
+
+    The queue enables multi-conversation orchestration where agents can
+    queue follow-up conversations that are processed by a heartbeat dispatcher.
+    """
+
+    enabled: bool = True
+    heartbeat_interval: int = 300  # seconds (5 min default)
+    max_dispatch: int = 5  # max items to process per heartbeat cycle
+
+
+@dataclass
 class Config:
     """Root configuration."""
 
@@ -82,6 +95,7 @@ class Config:
     groups: dict[str, GroupConfig] = field(default_factory=dict)
     tasks: dict[str, TaskConfig] = field(default_factory=dict)
     agent: AgentConfig = field(default_factory=AgentConfig)
+    queue: QueueConfig = field(default_factory=QueueConfig)
 
 
 def expand_env_vars(value: str) -> str:
@@ -203,4 +217,5 @@ def load_config(path: Path | str | None = None) -> Config:
         groups=_parse_groups(raw),
         tasks=_parse_tasks(raw),
         agent=AgentConfig(**raw.get("agent", {})),
+        queue=QueueConfig(**raw.get("queue", {})),
     )

--- a/src/openpaws/daemon.py
+++ b/src/openpaws/daemon.py
@@ -31,6 +31,7 @@ from openpaws.channels.campfire import CampfireAdapter, CampfireConfig
 from openpaws.channels.gmail import GmailAdapter, GmailConfig
 from openpaws.channels.slack import SlackAdapter, SlackConfig
 from openpaws.config import Config, load_config
+from openpaws.queue_manager import QueueManager
 from openpaws.runner import ConversationRunner
 from openpaws.scheduler import Scheduler
 from openpaws.storage import Storage
@@ -320,6 +321,13 @@ class Daemon:
         self._channel_adapters: list[ChannelAdapter] = []
         self._channel_adapters_by_type: dict[str, ChannelAdapter] = {}
         self._runner: ConversationRunner | None = None
+        self._queue_manager: QueueManager | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+
+    @property
+    def queue_manager(self) -> QueueManager | None:
+        """Get the queue manager instance."""
+        return self._queue_manager
 
     def _setup_signal_handlers(self) -> None:
         """Setup signal handlers for graceful shutdown."""
@@ -389,6 +397,7 @@ class Daemon:
 
     def _setup_runner(self) -> None:
         """Initialize the conversation runner."""
+        # Queue callback is set up later in _setup_queue_manager
         self._runner = ConversationRunner(self.config)
         logger.info("Conversation runner initialized")
 
@@ -401,6 +410,68 @@ class Daemon:
                 continue
             self.scheduler.add_task(task_config)
             logger.info(f"Scheduled task: {task_config.name}")
+
+    async def _queue_callback(
+        self,
+        prompt: str,
+        group_name: str,
+        context: dict | None,
+        priority: int,
+        workflow_id: str | None,
+    ) -> str:
+        """Queue a follow-up conversation. Used as callback for QueueNextTool."""
+        if not self._queue_manager:
+            raise RuntimeError("Queue manager not initialized")
+        return await self._queue_manager.enqueue(
+            prompt=prompt,
+            group_name=group_name,
+            context=context,
+            priority=priority,
+            workflow_id=workflow_id,
+        )
+
+    def _setup_queue_manager(self) -> None:
+        """Initialize queue manager for multi-conversation orchestration."""
+        if not self.config.queue.enabled:
+            logger.info("Queue dispatch disabled in config")
+            return
+
+        # Recreate runner with queue callback
+        self._runner = ConversationRunner(
+            self.config,
+            queue_callback=self._queue_callback,
+        )
+
+        self._queue_manager = QueueManager(
+            storage=self.storage,
+            runner=self._runner,
+            config=self.config.queue,
+        )
+        interval = self.config.queue.heartbeat_interval
+        max_dispatch = self.config.queue.max_dispatch
+        logger.info(f"Queue manager: interval={interval}s, max_dispatch={max_dispatch}")
+
+    async def _heartbeat_loop(self) -> None:
+        """Process queued conversations at configured interval."""
+        if not self._queue_manager:
+            return
+
+        interval = self.config.queue.heartbeat_interval
+        logger.info(f"Starting heartbeat loop with {interval}s interval")
+
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                if self._shutdown_event and self._shutdown_event.is_set():
+                    break
+                processed = await self._queue_manager.process_batch()
+                if processed > 0:
+                    logger.info(f"Heartbeat: processed {processed} queued item(s)")
+            except asyncio.CancelledError:
+                logger.info("Heartbeat loop cancelled")
+                break
+            except Exception as e:
+                logger.exception(f"Error in heartbeat loop: {e}")
 
     def _find_group_for_message(self, message: IncomingMessage) -> str | None:
         """Find the group name that matches the incoming message."""
@@ -583,6 +654,7 @@ class Daemon:
 
     async def _shutdown(self) -> None:
         """Perform graceful shutdown of all components."""
+        self._stop_heartbeat()
         await self._stop_channel_adapters()
         if self.scheduler:
             self.scheduler.stop()
@@ -598,7 +670,20 @@ class Daemon:
         self._setup_storage()
         self._setup_runner()
         self._setup_scheduler()
+        self._setup_queue_manager()
         self._setup_channel_adapters()
+
+    def _start_heartbeat_if_enabled(self) -> None:
+        """Start the heartbeat loop if queue manager is enabled."""
+        if self._queue_manager:
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+            logger.info("Heartbeat task started")
+
+    def _stop_heartbeat(self) -> None:
+        """Stop the heartbeat loop if running."""
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            logger.info("Heartbeat task cancelled")
 
     async def run(self) -> None:
         """Main daemon run loop."""
@@ -607,6 +692,7 @@ class Daemon:
         self._log_startup_info()
 
         self.scheduler.start(self._execute_task)
+        self._start_heartbeat_if_enabled()
         await self._start_channel_adapters()
         await self._shutdown_event.wait()
         await self._shutdown()

--- a/src/openpaws/daemon.py
+++ b/src/openpaws/daemon.py
@@ -430,43 +430,39 @@ class Daemon:
             workflow_id=workflow_id,
         )
 
-    def _setup_queue_manager(self) -> None:
+    def _setup_queue_manager(self) -> None:  # length-ok
         """Initialize queue manager for multi-conversation orchestration."""
         if not self.config.queue.enabled:
             logger.info("Queue dispatch disabled in config")
             return
-
-        # Recreate runner with queue callback
-        self._runner = ConversationRunner(
-            self.config,
-            queue_callback=self._queue_callback,
-        )
-
+        self._runner.set_queue_callback(self._queue_callback)
         self._queue_manager = QueueManager(
             storage=self.storage,
             runner=self._runner,
             config=self.config.queue,
         )
         interval = self.config.queue.heartbeat_interval
-        max_dispatch = self.config.queue.max_dispatch
-        logger.info(f"Queue manager: interval={interval}s, max_dispatch={max_dispatch}")
+        max_d = self.config.queue.max_dispatch
+        logger.info(f"Queue manager: interval={interval}s, max_dispatch={max_d}")
 
-    async def _heartbeat_loop(self) -> None:
+    async def _process_queue_batch(self) -> None:  # length-ok
+        """Process one batch and log results."""
+        if self._shutdown_event and self._shutdown_event.is_set():
+            return
+        processed = await self._queue_manager.process_batch()
+        if processed > 0:
+            logger.info(f"Heartbeat: processed {processed} queued item(s)")
+
+    async def _heartbeat_loop(self) -> None:  # length-ok
         """Process queued conversations at configured interval."""
         if not self._queue_manager:
             return
-
         interval = self.config.queue.heartbeat_interval
         logger.info(f"Starting heartbeat loop with {interval}s interval")
-
         while True:
             try:
+                await self._process_queue_batch()
                 await asyncio.sleep(interval)
-                if self._shutdown_event and self._shutdown_event.is_set():
-                    break
-                processed = await self._queue_manager.process_batch()
-                if processed > 0:
-                    logger.info(f"Heartbeat: processed {processed} queued item(s)")
             except asyncio.CancelledError:
                 logger.info("Heartbeat loop cancelled")
                 break

--- a/src/openpaws/queue_manager.py
+++ b/src/openpaws/queue_manager.py
@@ -45,7 +45,13 @@ class QueueManager:
     runner: ConversationRunner
     config: QueueConfig = field(default_factory=QueueConfig)
 
-    async def enqueue(
+    def _validate_group(self, group_name: str) -> None:
+        """Validate that group_name exists in config."""
+        if group_name not in self.runner.config.groups:
+            available = ", ".join(self.runner.config.groups.keys())
+            raise ValueError(f"Group '{group_name}' not found. Available: {available}")
+
+    async def enqueue(  # length-ok
         self,
         prompt: str,
         group_name: str,
@@ -55,19 +61,8 @@ class QueueManager:
         parent_conversation_id: str | None = None,
         workflow_id: str | None = None,
     ) -> str:
-        """Add a conversation to the queue.
-
-        Args:
-            prompt: The prompt for the queued conversation.
-            group_name: The group to run the conversation in.
-            context: Optional context dict to pass to the conversation.
-            priority: Priority level (higher = processed first). Default 0.
-            parent_conversation_id: ID of the parent conversation (for tracing).
-            workflow_id: ID to group related queue items.
-
-        Returns:
-            The ID of the queued item.
-        """
+        """Add a conversation to the queue."""
+        self._validate_group(group_name)
         item = QueueItem.create(
             prompt=prompt,
             group_name=group_name,
@@ -77,10 +72,7 @@ class QueueManager:
             workflow_id=workflow_id,
         )
         self.storage.enqueue(item)
-        logger.info(
-            f"Queued conversation for group '{group_name}' with id={item.id[:8]}... "
-            f"priority={priority}"
-        )
+        logger.info(f"Queued for '{group_name}' id={item.id[:8]} priority={priority}")
         return item.id
 
     def _build_prompt_with_context(self, item: QueueItem) -> str:
@@ -90,26 +82,27 @@ class QueueManager:
         context_str = "\n".join(f"- {k}: {v}" for k, v in item.context.items())
         return f"Context from previous conversation:\n{context_str}\n\n{item.prompt}"
 
+    def _handle_result(self, item: QueueItem, result) -> None:
+        """Handle the result of processing a queue item."""
+        if result.success:
+            self.storage.complete_queue_item(item.id, result.message)
+            logger.info(f"Queue item {item.id[:8]}... completed")
+        else:
+            self.storage.fail_queue_item(item.id, result.error or "Unknown error")
+            logger.warning(f"Queue item {item.id[:8]}... failed: {result.error}")
+
     async def _process_item(self, item: QueueItem) -> None:
         """Process a single queue item."""
-        logger.info(
-            f"Processing queue item {item.id[:8]}... for group '{item.group_name}'"
-        )
+        logger.info(f"Processing queue item {item.id[:8]} for '{item.group_name}'")
         try:
             prompt = self._build_prompt_with_context(item)
             result = await self.runner.run_prompt(
-                group_name=item.group_name,
-                prompt=prompt,
+                group_name=item.group_name, prompt=prompt
             )
-            if result.success:
-                self.storage.complete_queue_item(item.id, result.message)
-                logger.info(f"Queue item {item.id[:8]}... completed successfully")
-            else:
-                self.storage.fail_queue_item(item.id, result.error or "Unknown error")
-                logger.warning(f"Queue item {item.id[:8]}... failed: {result.error}")
+            self._handle_result(item, result)
         except Exception as e:
             self.storage.fail_queue_item(item.id, str(e))
-            logger.exception(f"Queue item {item.id[:8]}... failed with exception")
+            logger.exception(f"Queue item {item.id[:8]} failed with exception")
 
     async def process_batch(self) -> int:
         """Process up to max_dispatch items from the queue.

--- a/src/openpaws/queue_manager.py
+++ b/src/openpaws/queue_manager.py
@@ -1,0 +1,146 @@
+"""Queue manager for multi-conversation orchestration.
+
+This module provides the QueueManager class that:
+- Adds conversations to a persistent queue
+- Processes queued items at configurable intervals (heartbeat)
+- Integrates with ConversationRunner for execution
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from openpaws.config import QueueConfig
+from openpaws.runner import ConversationRunner
+from openpaws.storage import QueueItem, Storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QueueManager:
+    """Manages the conversation queue for multi-conversation workflows.
+
+    The QueueManager coordinates between:
+    - Storage: Persists queue items to SQLite
+    - ConversationRunner: Executes queued conversations
+    - Config: Controls heartbeat interval and max dispatch
+
+    Example:
+        >>> from openpaws.config import QueueConfig
+        >>> from openpaws.storage import Storage
+        >>> from openpaws.runner import ConversationRunner
+        >>>
+        >>> qm = QueueManager(
+        ...     storage=Storage(),
+        ...     runner=runner,
+        ...     config=QueueConfig(heartbeat_interval=60, max_dispatch=3),
+        ... )
+        >>> item_id = await qm.enqueue("Analyze results", "main", context={"step": 1})
+        >>> processed = await qm.process_batch()
+    """
+
+    storage: Storage
+    runner: ConversationRunner
+    config: QueueConfig = field(default_factory=QueueConfig)
+
+    async def enqueue(
+        self,
+        prompt: str,
+        group_name: str,
+        *,
+        context: dict | None = None,
+        priority: int = 0,
+        parent_conversation_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> str:
+        """Add a conversation to the queue.
+
+        Args:
+            prompt: The prompt for the queued conversation.
+            group_name: The group to run the conversation in.
+            context: Optional context dict to pass to the conversation.
+            priority: Priority level (higher = processed first). Default 0.
+            parent_conversation_id: ID of the parent conversation (for tracing).
+            workflow_id: ID to group related queue items.
+
+        Returns:
+            The ID of the queued item.
+        """
+        item = QueueItem.create(
+            prompt=prompt,
+            group_name=group_name,
+            context=context,
+            priority=priority,
+            parent_conversation_id=parent_conversation_id,
+            workflow_id=workflow_id,
+        )
+        self.storage.enqueue(item)
+        logger.info(
+            f"Queued conversation for group '{group_name}' with id={item.id[:8]}... "
+            f"priority={priority}"
+        )
+        return item.id
+
+    def _build_prompt_with_context(self, item: QueueItem) -> str:
+        """Build the prompt with context prepended if available."""
+        if not item.context:
+            return item.prompt
+        context_str = "\n".join(f"- {k}: {v}" for k, v in item.context.items())
+        return f"Context from previous conversation:\n{context_str}\n\n{item.prompt}"
+
+    async def _process_item(self, item: QueueItem) -> None:
+        """Process a single queue item."""
+        logger.info(
+            f"Processing queue item {item.id[:8]}... for group '{item.group_name}'"
+        )
+        try:
+            prompt = self._build_prompt_with_context(item)
+            result = await self.runner.run_prompt(
+                group_name=item.group_name,
+                prompt=prompt,
+            )
+            if result.success:
+                self.storage.complete_queue_item(item.id, result.message)
+                logger.info(f"Queue item {item.id[:8]}... completed successfully")
+            else:
+                self.storage.fail_queue_item(item.id, result.error or "Unknown error")
+                logger.warning(f"Queue item {item.id[:8]}... failed: {result.error}")
+        except Exception as e:
+            self.storage.fail_queue_item(item.id, str(e))
+            logger.exception(f"Queue item {item.id[:8]}... failed with exception")
+
+    async def process_batch(self) -> int:
+        """Process up to max_dispatch items from the queue.
+
+        Items are processed in priority order (highest first), then FIFO.
+        Each item is marked as 'processing' before execution to prevent
+        duplicate processing.
+
+        Returns:
+            The number of items processed.
+        """
+        if not self.config.enabled:
+            return 0
+
+        items = self.storage.dequeue(max_items=self.config.max_dispatch)
+        if not items:
+            return 0
+
+        for item in items:
+            await self._process_item(item)
+
+        return len(items)
+
+    def get_stats(self) -> dict[str, int]:
+        """Get queue statistics by status."""
+        return self.storage.get_queue_stats()
+
+    def list_pending(self) -> list[QueueItem]:
+        """List all pending queue items."""
+        return self.storage.list_queue(status="pending")
+
+    def clear_completed(self) -> int:
+        """Clear all completed queue items. Returns count deleted."""
+        return self.storage.clear_queue(status="completed")

--- a/src/openpaws/runner.py
+++ b/src/openpaws/runner.py
@@ -119,6 +119,10 @@ class ConversationRunner:
         # Note: Agent is not cached because it may need different tools per conversation
         # (e.g., different send_callback for different channels)
 
+    def set_queue_callback(self, callback: QueueCallback) -> None:
+        """Set or update the queue callback after initialization."""
+        self._queue_callback = callback
+
     @property
     def llm(self) -> LLM:
         """Get or create the LLM instance."""

--- a/src/openpaws/runner.py
+++ b/src/openpaws/runner.py
@@ -21,8 +21,11 @@ from pydantic import SecretStr
 
 from openpaws.config import Config, GroupConfig
 from openpaws.tools import (
+    QueueNextTool,
     SendStatusTool,
+    register_queue_callback,
     register_send_callback,
+    unregister_queue_callback,
     unregister_send_callback,
 )
 
@@ -34,12 +37,12 @@ def _register_openpaws_tools() -> None:
     """Register OpenPaws custom tools with the SDK."""
     from openhands.sdk.tool import register_tool
 
-    # Register SendStatusTool if not already registered
-    try:
-        register_tool(SendStatusTool.name, SendStatusTool)
-    except ValueError:
-        # Already registered
-        pass
+    # Register tools if not already registered
+    for tool_cls in [SendStatusTool, QueueNextTool]:
+        try:
+            register_tool(tool_cls.name, tool_cls)
+        except ValueError:
+            pass  # Already registered
 
 
 # Register tools at module load time
@@ -47,6 +50,8 @@ _register_openpaws_tools()
 
 # Type for status message callback
 SendCallback = Callable[[str], Awaitable[None]]
+# Type for queue callback
+QueueCallback = Callable[[str, str, dict | None, int, str | None], Awaitable[str]]
 
 # Instructions for the agent on handling immediate vs. deferred responses
 CHAT_RESPONSE_INSTRUCTIONS = """
@@ -97,15 +102,18 @@ class ConversationRunner:
         self,
         config: Config,
         base_dir: Path | None = None,
+        queue_callback: QueueCallback | None = None,
     ):
         """Initialize the conversation runner.
 
         Args:
             config: OpenPaws configuration
             base_dir: Base directory for OpenPaws data (default: ~/.openpaws)
+            queue_callback: Optional callback for queuing follow-up conversations
         """
         self.config = config
         self.base_dir = base_dir or Path.home() / ".openpaws"
+        self._queue_callback = queue_callback
 
         self._llm: LLM | None = None
         # Note: Agent is not cached because it may need different tools per conversation
@@ -269,10 +277,19 @@ class ConversationRunner:
             error=str(e),
         )
 
-    def _register_callback(self, conv, send_callback: SendCallback | None) -> None:
-        """Register send callback if provided."""
+    def _register_callbacks(self, conv, send_callback: SendCallback | None) -> None:
+        """Register tool callbacks for this conversation."""
+        conv_id = str(conv.state.id)
         if send_callback:
-            register_send_callback(str(conv.state.id), send_callback)
+            register_send_callback(conv_id, send_callback)
+        if self._queue_callback:
+            register_queue_callback(conv_id, self._queue_callback)
+
+    def _unregister_callbacks(self, conv) -> None:
+        """Unregister tool callbacks for this conversation."""
+        conv_id = str(conv.state.id)
+        unregister_send_callback(conv_id)
+        unregister_queue_callback(conv_id)
 
     async def _execute_prompt(
         self, group: GroupConfig, prompt: str, conversation_id, callbacks, send_callback
@@ -283,13 +300,13 @@ class ConversationRunner:
         try:
             cbs = self._build_callbacks(events, callbacks)
             conv = self._create_conversation(group, conversation_id, cbs)
-            self._register_callback(conv, send_callback)
+            self._register_callbacks(conv, send_callback)
             return self._run_conversation(conv, prompt, events)
         except Exception as e:
             return self._conversation_error(e, events)
         finally:
             if conv:
-                unregister_send_callback(str(conv.state.id))
+                self._unregister_callbacks(conv)
 
     async def run_prompt(
         self,

--- a/src/openpaws/storage.py
+++ b/src/openpaws/storage.py
@@ -451,14 +451,15 @@ class Storage:
         self, status: str | None = None, limit: int | None = None
     ) -> list[QueueItem]:
         """List queue items, optionally filtered by status."""
+        order = "ORDER BY priority DESC, created_at ASC"
         with self._connection() as conn:
             if status:
-                query = "SELECT * FROM queue WHERE status = ? ORDER BY priority DESC, created_at ASC"
+                query = f"SELECT * FROM queue WHERE status = ? {order}"
                 if limit:
                     query += f" LIMIT {limit}"
                 rows = conn.execute(query, (status,)).fetchall()
             else:
-                query = "SELECT * FROM queue ORDER BY priority DESC, created_at ASC"
+                query = f"SELECT * FROM queue {order}"
                 if limit:
                     query += f" LIMIT {limit}"
                 rows = conn.execute(query).fetchall()

--- a/src/openpaws/storage.py
+++ b/src/openpaws/storage.py
@@ -3,15 +3,18 @@
 This module provides persistent storage for:
 - Task state (next_run, last_run, status, last_result)
 - Conversation sessions (for resume capability)
+- Queue items for multi-conversation orchestration
 
 Database location: ~/.openpaws/state.db (or $OPENPAWS_DIR/state.db)
 """
 
+import json
 import os
 import sqlite3
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -53,6 +56,24 @@ CREATE TABLE IF NOT EXISTS sessions (
     updated_at TEXT,
     state BLOB
 );
+
+CREATE TABLE IF NOT EXISTS queue (
+    id TEXT PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    context TEXT,
+    group_name TEXT NOT NULL,
+    priority INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    processed_at TEXT,
+    result TEXT,
+    error TEXT,
+    parent_conversation_id TEXT,
+    workflow_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_status_priority 
+    ON queue(status, priority DESC, created_at ASC);
 """
 
 
@@ -79,6 +100,47 @@ class SessionState:
     created_at: datetime
     updated_at: datetime
     state: bytes | None = None
+
+
+@dataclass
+class QueueItem:
+    """A queued conversation for multi-conversation orchestration."""
+
+    id: str
+    prompt: str
+    group_name: str
+    priority: int = 0
+    status: str = "pending"  # pending, processing, completed, failed
+    created_at: datetime = field(default_factory=datetime.now)
+    processed_at: datetime | None = None
+    result: str | None = None
+    error: str | None = None
+    context: dict | None = None
+    parent_conversation_id: str | None = None
+    workflow_id: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        prompt: str,
+        group_name: str,
+        *,
+        context: dict | None = None,
+        priority: int = 0,
+        parent_conversation_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> "QueueItem":
+        """Create a new queue item with generated ID."""
+        return cls(
+            id=str(uuid.uuid4()),
+            prompt=prompt,
+            group_name=group_name,
+            context=context,
+            priority=priority,
+            parent_conversation_id=parent_conversation_id,
+            workflow_id=workflow_id,
+            created_at=datetime.now(),
+        )
 
 
 def _datetime_to_str(dt: datetime | None) -> str | None:
@@ -269,3 +331,161 @@ class Storage:
             if row is None:
                 return None
             return self._row_to_session(row)
+
+    # Queue persistence methods
+
+    _INSERT_QUEUE_SQL = """
+        INSERT INTO queue
+            (id, prompt, context, group_name, priority, status,
+             created_at, processed_at, result, error,
+             parent_conversation_id, workflow_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    def _queue_item_to_row(self, item: QueueItem) -> tuple:
+        """Convert QueueItem to a tuple for SQL insertion."""
+        return (
+            item.id,
+            item.prompt,
+            json.dumps(item.context) if item.context else None,
+            item.group_name,
+            item.priority,
+            item.status,
+            _datetime_to_str(item.created_at),
+            _datetime_to_str(item.processed_at),
+            item.result,
+            item.error,
+            item.parent_conversation_id,
+            item.workflow_id,
+        )
+
+    def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:
+        """Convert a database row to QueueItem."""
+        context = row["context"]
+        return QueueItem(
+            id=row["id"],
+            prompt=row["prompt"],
+            context=json.loads(context) if context else None,
+            group_name=row["group_name"],
+            priority=row["priority"],
+            status=row["status"],
+            created_at=_str_to_datetime(row["created_at"]),
+            processed_at=_str_to_datetime(row["processed_at"]),
+            result=row["result"],
+            error=row["error"],
+            parent_conversation_id=row["parent_conversation_id"],
+            workflow_id=row["workflow_id"],
+        )
+
+    def enqueue(self, item: QueueItem) -> str:
+        """Add a queue item. Returns the item ID."""
+        with self._connection() as conn:
+            conn.execute(self._INSERT_QUEUE_SQL, self._queue_item_to_row(item))
+        return item.id
+
+    def dequeue(self, max_items: int = 1) -> list[QueueItem]:
+        """Fetch pending items and mark as processing.
+
+        Items are ordered by priority (descending) then created_at (ascending).
+        """
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM queue
+                WHERE status = 'pending'
+                ORDER BY priority DESC, created_at ASC
+                LIMIT ?
+                """,
+                (max_items,),
+            ).fetchall()
+
+            items = [self._row_to_queue_item(row) for row in rows]
+
+            # Mark as processing
+            for item in items:
+                conn.execute(
+                    "UPDATE queue SET status = 'processing' WHERE id = ?",
+                    (item.id,),
+                )
+                item.status = "processing"
+
+        return items
+
+    def complete_queue_item(self, item_id: str, result: str) -> bool:
+        """Mark a queue item as completed. Returns True if updated."""
+        with self._connection() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE queue 
+                SET status = 'completed', result = ?, processed_at = ?
+                WHERE id = ?
+                """,
+                (result, _datetime_to_str(datetime.now()), item_id),
+            )
+            return cursor.rowcount > 0
+
+    def fail_queue_item(self, item_id: str, error: str) -> bool:
+        """Mark a queue item as failed. Returns True if updated."""
+        with self._connection() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE queue 
+                SET status = 'failed', error = ?, processed_at = ?
+                WHERE id = ?
+                """,
+                (error, _datetime_to_str(datetime.now()), item_id),
+            )
+            return cursor.rowcount > 0
+
+    def load_queue_item(self, item_id: str) -> QueueItem | None:
+        """Load a queue item by ID."""
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM queue WHERE id = ?", (item_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            return self._row_to_queue_item(row)
+
+    def list_queue(self, status: str | None = None) -> list[QueueItem]:
+        """List queue items, optionally filtered by status."""
+        with self._connection() as conn:
+            if status:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM queue WHERE status = ?
+                    ORDER BY priority DESC, created_at ASC
+                    """,
+                    (status,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM queue
+                    ORDER BY priority DESC, created_at ASC
+                    """
+                ).fetchall()
+            return [self._row_to_queue_item(row) for row in rows]
+
+    def clear_queue(self, status: str | None = None) -> int:
+        """Clear queue items, optionally filtered by status. Returns count deleted."""
+        with self._connection() as conn:
+            if status:
+                cursor = conn.execute(
+                    "DELETE FROM queue WHERE status = ?", (status,)
+                )
+            else:
+                cursor = conn.execute("DELETE FROM queue")
+            return cursor.rowcount
+
+    def get_queue_stats(self) -> dict[str, int]:
+        """Get queue statistics by status."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT status, COUNT(*) as count
+                FROM queue
+                GROUP BY status
+                """
+            ).fetchall()
+            return {row["status"]: row["count"] for row in rows}

--- a/src/openpaws/storage.py
+++ b/src/openpaws/storage.py
@@ -447,33 +447,28 @@ class Storage:
                 return None
             return self._row_to_queue_item(row)
 
-    def list_queue(self, status: str | None = None) -> list[QueueItem]:
+    def list_queue(
+        self, status: str | None = None, limit: int | None = None
+    ) -> list[QueueItem]:
         """List queue items, optionally filtered by status."""
         with self._connection() as conn:
             if status:
-                rows = conn.execute(
-                    """
-                    SELECT * FROM queue WHERE status = ?
-                    ORDER BY priority DESC, created_at ASC
-                    """,
-                    (status,),
-                ).fetchall()
+                query = "SELECT * FROM queue WHERE status = ? ORDER BY priority DESC, created_at ASC"
+                if limit:
+                    query += f" LIMIT {limit}"
+                rows = conn.execute(query, (status,)).fetchall()
             else:
-                rows = conn.execute(
-                    """
-                    SELECT * FROM queue
-                    ORDER BY priority DESC, created_at ASC
-                    """
-                ).fetchall()
+                query = "SELECT * FROM queue ORDER BY priority DESC, created_at ASC"
+                if limit:
+                    query += f" LIMIT {limit}"
+                rows = conn.execute(query).fetchall()
             return [self._row_to_queue_item(row) for row in rows]
 
     def clear_queue(self, status: str | None = None) -> int:
         """Clear queue items, optionally filtered by status. Returns count deleted."""
         with self._connection() as conn:
             if status:
-                cursor = conn.execute(
-                    "DELETE FROM queue WHERE status = ?", (status,)
-                )
+                cursor = conn.execute("DELETE FROM queue WHERE status = ?", (status,))
             else:
                 cursor = conn.execute("DELETE FROM queue")
             return cursor.rowcount

--- a/src/openpaws/storage.py
+++ b/src/openpaws/storage.py
@@ -447,7 +447,7 @@ class Storage:
                 return None
             return self._row_to_queue_item(row)
 
-    def list_queue(
+    def list_queue(  # length-ok: SQL query building requires steps
         self, status: str | None = None, limit: int | None = None
     ) -> list[QueueItem]:
         """List queue items, optionally filtered by status."""

--- a/src/openpaws/storage.py
+++ b/src/openpaws/storage.py
@@ -342,7 +342,7 @@ class Storage:
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
-    def _queue_item_to_row(self, item: QueueItem) -> tuple:
+    def _queue_item_to_row(self, item: QueueItem) -> tuple:  # length-ok
         """Convert QueueItem to a tuple for SQL insertion."""
         return (
             item.id,
@@ -359,7 +359,7 @@ class Storage:
             item.workflow_id,
         )
 
-    def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:
+    def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:  # length-ok
         """Convert a database row to QueueItem."""
         context = row["context"]
         return QueueItem(

--- a/src/openpaws/tools/__init__.py
+++ b/src/openpaws/tools/__init__.py
@@ -1,9 +1,21 @@
 """OpenPaws custom tools."""
 
+from openpaws.tools.queue_next import (
+    QueueNextTool,
+    register_queue_callback,
+    unregister_queue_callback,
+)
 from openpaws.tools.send_status import (
     SendStatusTool,
     register_send_callback,
     unregister_send_callback,
 )
 
-__all__ = ["SendStatusTool", "register_send_callback", "unregister_send_callback"]
+__all__ = [
+    "QueueNextTool",
+    "register_queue_callback",
+    "unregister_queue_callback",
+    "SendStatusTool",
+    "register_send_callback",
+    "unregister_send_callback",
+]

--- a/src/openpaws/tools/queue_next.py
+++ b/src/openpaws/tools/queue_next.py
@@ -134,16 +134,19 @@ interval.
 Keep prompts specific and actionable. Include relevant context from current work."""
 
 
-def _run_async_callback(callback, *args) -> str | None:
-    """Run an async callback, handling event loop conflicts."""
+def _run_async_callback(callback, *args) -> str | None:  # length-ok
+    """Run an async callback from a sync context using a thread pool."""
     import asyncio
     import concurrent.futures
+    import logging
 
-    try:
-        with concurrent.futures.ThreadPoolExecutor() as pool:
+    logger = logging.getLogger(__name__)
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        try:
             return pool.submit(asyncio.run, callback(*args)).result()
-    except Exception:
-        return asyncio.run(callback(*args))
+        except Exception as e:
+            logger.exception(f"Failed to execute queue callback: {e}")
+            raise RuntimeError(f"Queue callback execution failed: {e}") from e
 
 
 class QueueNextExecutor(ToolExecutor):
@@ -155,22 +158,34 @@ class QueueNextExecutor(ToolExecutor):
             return get_queue_callback(str(conversation.state.id))
         return None
 
-    def __call__(
-        self,
-        action: QueueNextAction,
-        conversation: BaseConversation | None = None,
-    ) -> QueueNextObservation:
-        queue_callback = self._get_callback(conversation)
+    def _no_callback_response(self) -> QueueNextObservation:
+        """Return observation when no callback is configured."""
+        return QueueNextObservation.from_text(
+            text="Queue not available (no callback configured).",
+            queued=False,
+            item_id=None,
+        )
 
-        if queue_callback is None:
-            return QueueNextObservation.from_text(
-                text="Queue not available (no callback configured).",
-                queued=False,
-                item_id=None,
-            )
+    def _success_response(self, item_id: str) -> QueueNextObservation:
+        """Return observation for successful queue."""
+        return QueueNextObservation.from_text(
+            text=f"Follow-up conversation queued with id={item_id[:8]}...",
+            queued=True,
+            item_id=item_id,
+        )
 
-        item_id = _run_async_callback(
-            queue_callback,
+    def _failure_response(self) -> QueueNextObservation:
+        """Return observation for failed queue."""
+        return QueueNextObservation.from_text(
+            text="Failed to queue follow-up conversation.",
+            queued=False,
+            item_id=None,
+        )
+
+    def _execute_callback(self, callback, action: QueueNextAction) -> str | None:
+        """Execute the queue callback with action parameters."""
+        return _run_async_callback(
+            callback,
             action.prompt,
             action.group_name,
             action.context,
@@ -178,17 +193,16 @@ class QueueNextExecutor(ToolExecutor):
             action.workflow_id,
         )
 
-        if item_id:
-            return QueueNextObservation.from_text(
-                text=f"Follow-up conversation queued with id={item_id[:8]}...",
-                queued=True,
-                item_id=item_id,
-            )
-        return QueueNextObservation.from_text(
-            text="Failed to queue follow-up conversation.",
-            queued=False,
-            item_id=None,
-        )
+    def __call__(
+        self,
+        action: QueueNextAction,
+        conversation: BaseConversation | None = None,
+    ) -> QueueNextObservation:
+        callback = self._get_callback(conversation)
+        if callback is None:
+            return self._no_callback_response()
+        item_id = self._execute_callback(callback, action)
+        return self._success_response(item_id) if item_id else self._failure_response()
 
 
 class QueueNextTool(ToolDefinition[QueueNextAction, QueueNextObservation]):

--- a/src/openpaws/tools/queue_next.py
+++ b/src/openpaws/tools/queue_next.py
@@ -49,9 +49,7 @@ def get_queue_callback(conversation_id: str) -> QueueCallback | None:
 class QueueNextAction(Action):
     """Action for queuing a follow-up conversation."""
 
-    prompt: str = Field(
-        description="The prompt for the follow-up conversation"
-    )
+    prompt: str = Field(description="The prompt for the follow-up conversation")
     group_name: str = Field(
         description="The group to run the follow-up conversation in"
     )
@@ -88,9 +86,7 @@ class QueueNextObservation(Observation):
     queued: bool = Field(
         default=True, description="Whether the conversation was queued"
     )
-    item_id: str | None = Field(
-        default=None, description="The ID of the queued item"
-    )
+    item_id: str | None = Field(default=None, description="The ID of the queued item")
 
     @property
     def visualize(self) -> Text:

--- a/src/openpaws/tools/queue_next.py
+++ b/src/openpaws/tools/queue_next.py
@@ -1,0 +1,224 @@
+"""QueueNextTool - allows agents to queue follow-up conversations.
+
+This tool enables agents to schedule follow-up conversations that will be
+processed by the heartbeat dispatcher, enabling multi-step workflows that
+span multiple conversations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from typing import TYPE_CHECKING, Self
+
+from openhands.sdk.tool.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    ToolExecutor,
+)
+from pydantic import Field
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.base import BaseConversation
+    from openhands.sdk.conversation.state import ConversationState
+
+# Type for the callback that queues conversations
+QueueCallback = Callable[[str, str, dict | None, int, str | None], Awaitable[str]]
+
+# Registry to store callbacks by conversation ID
+_callback_registry: dict[str, QueueCallback] = {}
+
+
+def register_queue_callback(conversation_id: str, callback: QueueCallback) -> None:
+    """Register a queue callback for a conversation."""
+    _callback_registry[conversation_id] = callback
+
+
+def unregister_queue_callback(conversation_id: str) -> None:
+    """Unregister a queue callback for a conversation."""
+    _callback_registry.pop(conversation_id, None)
+
+
+def get_queue_callback(conversation_id: str) -> QueueCallback | None:
+    """Get the queue callback for a conversation."""
+    return _callback_registry.get(conversation_id)
+
+
+class QueueNextAction(Action):
+    """Action for queuing a follow-up conversation."""
+
+    prompt: str = Field(
+        description="The prompt for the follow-up conversation"
+    )
+    group_name: str = Field(
+        description="The group to run the follow-up conversation in"
+    )
+    context: dict | None = Field(
+        default=None,
+        description="Optional context to pass to the follow-up conversation",
+    )
+    priority: int = Field(
+        default=0,
+        description="Priority level (higher = processed first). Default 0.",
+    )
+    workflow_id: str | None = Field(
+        default=None,
+        description="Optional workflow ID to group related conversations",
+    )
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation."""
+        content = Text()
+        content.append("📋 ", style="cyan")
+        content.append("Queuing follow-up: ", style="bold cyan")
+        prompt_preview = (
+            self.prompt[:50] + "..." if len(self.prompt) > 50 else self.prompt
+        )
+        content.append(prompt_preview, style="white")
+        content.append(f" (group={self.group_name})", style="dim")
+        return content
+
+
+class QueueNextObservation(Observation):
+    """Observation returned after queuing a conversation."""
+
+    queued: bool = Field(
+        default=True, description="Whether the conversation was queued"
+    )
+    item_id: str | None = Field(
+        default=None, description="The ID of the queued item"
+    )
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation."""
+        content = Text()
+        if self.queued:
+            content.append("✓ ", style="green")
+            content.append("Follow-up queued", style="green")
+            if self.item_id:
+                content.append(f" (id={self.item_id[:8]}...)", style="dim")
+        else:
+            content.append("✗ ", style="red")
+            content.append("Failed to queue follow-up conversation", style="red")
+        return content
+
+
+QUEUE_NEXT_DESCRIPTION = """Queue a follow-up conversation for later processing.
+
+Use this tool when a workflow should continue in a separate conversation,
+allowing the current conversation to complete and free resources. The queued
+conversation will be processed by the heartbeat dispatcher at the configured
+interval.
+
+**When to use:**
+- Multi-step workflows that benefit from context separation
+- Long-running operations that should be broken into discrete steps
+- Workflows that need to wait for external events between steps
+
+**Parameters:**
+- prompt: The task description for the follow-up conversation
+- group_name: Which group to run the conversation in (must match config)
+- context: Optional dict of key-value pairs to pass to the next step
+- priority: Higher numbers are processed first (default: 0)
+- workflow_id: Optional ID to track related conversations
+
+**Example workflow:**
+1. Current conversation: "Build remediation plan" → queue next step
+2. Queued conversation: "Open PR with fixes" → queue validation
+3. Queued conversation: "Run tests and validate" → complete
+
+Keep prompts specific and actionable. Include relevant context from current work."""
+
+
+def _run_async_callback(callback, *args) -> str | None:
+    """Run an async callback, handling event loop conflicts."""
+    import asyncio
+    import concurrent.futures
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            return pool.submit(asyncio.run, callback(*args)).result()
+    except Exception:
+        return asyncio.run(callback(*args))
+
+
+class QueueNextExecutor(ToolExecutor):
+    """Executor that queues conversations via callback looked up from registry."""
+
+    def _get_callback(self, conversation) -> QueueCallback | None:
+        """Look up the callback from the registry using conversation ID."""
+        if conversation and hasattr(conversation, "state"):
+            return get_queue_callback(str(conversation.state.id))
+        return None
+
+    def __call__(
+        self,
+        action: QueueNextAction,
+        conversation: BaseConversation | None = None,
+    ) -> QueueNextObservation:
+        queue_callback = self._get_callback(conversation)
+
+        if queue_callback is None:
+            return QueueNextObservation.from_text(
+                text="Queue not available (no callback configured).",
+                queued=False,
+                item_id=None,
+            )
+
+        item_id = _run_async_callback(
+            queue_callback,
+            action.prompt,
+            action.group_name,
+            action.context,
+            action.priority,
+            action.workflow_id,
+        )
+
+        if item_id:
+            return QueueNextObservation.from_text(
+                text=f"Follow-up conversation queued with id={item_id[:8]}...",
+                queued=True,
+                item_id=item_id,
+            )
+        return QueueNextObservation.from_text(
+            text="Failed to queue follow-up conversation.",
+            queued=False,
+            item_id=None,
+        )
+
+
+class QueueNextTool(ToolDefinition[QueueNextAction, QueueNextObservation]):
+    """Tool for queuing follow-up conversations."""
+
+    @classmethod
+    def _make_annotations(cls) -> ToolAnnotations:
+        """Create tool annotations for the queue_next tool."""
+        return ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        )
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: ConversationState | None = None,
+        **params,  # noqa: ARG003
+    ) -> Sequence[Self]:
+        """Create QueueNextTool instance."""
+        if params:
+            raise ValueError(f"QueueNextTool doesn't accept: {list(params.keys())}")
+        return [
+            cls(
+                description=QUEUE_NEXT_DESCRIPTION,
+                action_type=QueueNextAction,
+                observation_type=QueueNextObservation,
+                executor=QueueNextExecutor(),
+                annotations=cls._make_annotations(),
+            )
+        ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,7 +588,8 @@ class TestQueueCommands:
 
     def test_queue_add_invalid_group(self, runner, config_file, isolated_env):
         """Test queue add with invalid group shows error."""
-        result = runner.invoke(main, ["queue", "add", "Test prompt", "-g", "nonexistent"])
+        args = ["queue", "add", "Test prompt", "-g", "nonexistent"]
+        result = runner.invoke(main, args)
         assert result.exit_code == 1
         assert "not found" in result.output.lower()
 
@@ -621,7 +622,9 @@ class TestQueueCommands:
         assert result.exit_code == 0
         assert "Deleted" in result.output
 
-    def test_queue_clear_all_requires_confirmation(self, runner, config_file, isolated_env):
+    def test_queue_clear_all_requires_confirmation(
+        self, runner, config_file, isolated_env
+    ):
         """Test queue clear all prompts for confirmation."""
         result = runner.invoke(main, ["queue", "clear", "-s", "all"])
         # Without -y, should prompt and abort on empty stdin
@@ -633,4 +636,3 @@ class TestQueueCommands:
         result = runner.invoke(main, ["queue", "clear", "-s", "all", "-y"])
         assert result.exit_code == 0
         assert "Deleted" in result.output
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,3 +562,75 @@ class TestCampfireSetupHelpers:
         result = []
         assert _handle_prompt_char("\x7f", result, echo=False) is False
         assert result == []
+
+
+class TestQueueCommands:
+    """Tests for queue CLI commands."""
+
+    def test_queue_list_empty(self, runner, isolated_env):
+        """Test queue list with empty queue."""
+        result = runner.invoke(main, ["queue", "list"])
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+
+    def test_queue_stats_empty(self, runner, isolated_env):
+        """Test queue stats with empty queue."""
+        result = runner.invoke(main, ["queue", "stats"])
+        assert result.exit_code == 0
+        assert "Pending:" in result.output
+        assert "0" in result.output
+
+    def test_queue_add_requires_group(self, runner, isolated_env):
+        """Test queue add without group fails."""
+        result = runner.invoke(main, ["queue", "add", "Test prompt"])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+    def test_queue_add_invalid_group(self, runner, config_file, isolated_env):
+        """Test queue add with invalid group shows error."""
+        result = runner.invoke(main, ["queue", "add", "Test prompt", "-g", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_queue_add_valid_group(self, runner, config_file, isolated_env):
+        """Test queue add with valid group succeeds."""
+        result = runner.invoke(main, ["queue", "add", "Test prompt", "-g", "main"])
+        assert result.exit_code == 0
+        assert "Queued" in result.output
+
+    def test_queue_list_shows_added_item(self, runner, config_file, isolated_env):
+        """Test queue list shows added item."""
+        runner.invoke(main, ["queue", "add", "Test prompt", "-g", "main"])
+        result = runner.invoke(main, ["queue", "list"])
+        assert result.exit_code == 0
+        assert "Test prompt" in result.output or "pending" in result.output.lower()
+
+    def test_queue_stats_counts_items(self, runner, config_file, isolated_env):
+        """Test queue stats counts items correctly."""
+        runner.invoke(main, ["queue", "add", "Test 1", "-g", "main"])
+        runner.invoke(main, ["queue", "add", "Test 2", "-g", "main"])
+        result = runner.invoke(main, ["queue", "stats"])
+        assert result.exit_code == 0
+        assert "Pending:" in result.output
+        # Should show 2 pending
+        assert "2" in result.output
+
+    def test_queue_clear_completed(self, runner, config_file, isolated_env):
+        """Test queue clear with default status."""
+        result = runner.invoke(main, ["queue", "clear", "-y"])
+        assert result.exit_code == 0
+        assert "Deleted" in result.output
+
+    def test_queue_clear_all_requires_confirmation(self, runner, config_file, isolated_env):
+        """Test queue clear all prompts for confirmation."""
+        result = runner.invoke(main, ["queue", "clear", "-s", "all"])
+        # Without -y, should prompt and abort on empty stdin
+        assert "Aborted" in result.output or result.exit_code == 1
+
+    def test_queue_clear_all_with_yes(self, runner, config_file, isolated_env):
+        """Test queue clear all with -y flag."""
+        runner.invoke(main, ["queue", "add", "Test", "-g", "main"])
+        result = runner.invoke(main, ["queue", "clear", "-s", "all", "-y"])
+        assert result.exit_code == 0
+        assert "Deleted" in result.output
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 
 from openpaws.config import (
+    QueueConfig,
     _parse_interval,
     _validate_task_schedule,
     expand_env_vars,
@@ -403,5 +404,146 @@ tasks:
             assert config.tasks["active-task"].enabled is True
             assert config.tasks["paused-task"].enabled is False
             assert config.tasks["default-task"].enabled is True
+
+        os.unlink(f.name)
+
+
+class TestQueueConfig:
+    """Tests for queue configuration."""
+
+    def test_queue_config_defaults(self):
+        """Test QueueConfig default values."""
+        config = QueueConfig()
+        assert config.enabled is True
+        assert config.heartbeat_interval == 300
+        assert config.max_dispatch == 5
+
+    def test_load_queue_config_defaults(self):
+        """Test that queue config uses defaults when not specified."""
+        config_content = """
+channels:
+  telegram:
+    bot_token: "test-token"
+
+groups:
+  main:
+    channel: telegram
+    chat_id: "123"
+
+tasks:
+  daily:
+    schedule: "0 9 * * *"
+    group: main
+    prompt: "Daily summary"
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            config = load_config(f.name)
+            assert config.queue.enabled is True
+            assert config.queue.heartbeat_interval == 300
+            assert config.queue.max_dispatch == 5
+
+        os.unlink(f.name)
+
+    def test_load_queue_config_custom(self):
+        """Test loading custom queue configuration."""
+        config_content = """
+channels:
+  telegram:
+    bot_token: "test-token"
+
+groups:
+  main:
+    channel: telegram
+    chat_id: "123"
+
+tasks:
+  daily:
+    schedule: "0 9 * * *"
+    group: main
+    prompt: "Daily summary"
+
+queue:
+  enabled: true
+  heartbeat_interval: 60
+  max_dispatch: 10
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            config = load_config(f.name)
+            assert config.queue.enabled is True
+            assert config.queue.heartbeat_interval == 60
+            assert config.queue.max_dispatch == 10
+
+        os.unlink(f.name)
+
+    def test_load_queue_config_disabled(self):
+        """Test loading queue config with enabled: false."""
+        config_content = """
+channels:
+  telegram:
+    bot_token: "test-token"
+
+groups:
+  main:
+    channel: telegram
+    chat_id: "123"
+
+tasks:
+  daily:
+    schedule: "0 9 * * *"
+    group: main
+    prompt: "Daily summary"
+
+queue:
+  enabled: false
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            config = load_config(f.name)
+            assert config.queue.enabled is False
+            # Other defaults should still apply
+            assert config.queue.heartbeat_interval == 300
+            assert config.queue.max_dispatch == 5
+
+        os.unlink(f.name)
+
+    def test_load_queue_config_partial(self):
+        """Test loading queue config with partial options."""
+        config_content = """
+channels:
+  telegram:
+    bot_token: "test-token"
+
+groups:
+  main:
+    channel: telegram
+    chat_id: "123"
+
+tasks:
+  daily:
+    schedule: "0 9 * * *"
+    group: main
+    prompt: "Daily summary"
+
+queue:
+  heartbeat_interval: 120
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            config = load_config(f.name)
+            # Specified value
+            assert config.queue.heartbeat_interval == 120
+            # Defaults for unspecified
+            assert config.queue.enabled is True
+            assert config.queue.max_dispatch == 5
 
         os.unlink(f.name)

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,283 @@
+"""Tests for queue manager."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openpaws.config import QueueConfig
+from openpaws.queue_manager import QueueManager
+from openpaws.runner import ConversationResult
+from openpaws.storage import Storage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """Create a storage instance with a temporary database."""
+    db_path = tmp_path / "test_state.db"
+    return Storage(db_path=db_path)
+
+
+@pytest.fixture
+def mock_runner():
+    """Create a mock runner."""
+    runner = MagicMock()
+    runner.run_prompt = AsyncMock(
+        return_value=ConversationResult(success=True, message="Test response")
+    )
+    return runner
+
+
+@pytest.fixture
+def queue_manager(storage, mock_runner):
+    """Create a queue manager with default config."""
+    return QueueManager(
+        storage=storage,
+        runner=mock_runner,
+        config=QueueConfig(),
+    )
+
+
+class TestEnqueue:
+    """Tests for enqueueing items."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_basic(self, queue_manager, storage):
+        """Test basic enqueueing."""
+        item_id = await queue_manager.enqueue(
+            prompt="Test prompt",
+            group_name="main",
+        )
+        assert item_id is not None
+
+        # Verify item is in storage
+        item = storage.load_queue_item(item_id)
+        assert item is not None
+        assert item.prompt == "Test prompt"
+        assert item.group_name == "main"
+        assert item.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_context(self, queue_manager, storage):
+        """Test enqueueing with context."""
+        item_id = await queue_manager.enqueue(
+            prompt="Test prompt",
+            group_name="main",
+            context={"key": "value", "step": 1},
+        )
+
+        item = storage.load_queue_item(item_id)
+        assert item.context == {"key": "value", "step": 1}
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_priority(self, queue_manager, storage):
+        """Test enqueueing with priority."""
+        item_id = await queue_manager.enqueue(
+            prompt="Test prompt",
+            group_name="main",
+            priority=10,
+        )
+
+        item = storage.load_queue_item(item_id)
+        assert item.priority == 10
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_workflow_id(self, queue_manager, storage):
+        """Test enqueueing with workflow ID."""
+        item_id = await queue_manager.enqueue(
+            prompt="Test prompt",
+            group_name="main",
+            workflow_id="workflow-123",
+            parent_conversation_id="parent-456",
+        )
+
+        item = storage.load_queue_item(item_id)
+        assert item.workflow_id == "workflow-123"
+        assert item.parent_conversation_id == "parent-456"
+
+
+class TestProcessBatch:
+    """Tests for processing queue batches."""
+
+    @pytest.mark.asyncio
+    async def test_process_empty_queue(self, queue_manager):
+        """Test processing empty queue returns 0."""
+        processed = await queue_manager.process_batch()
+        assert processed == 0
+
+    @pytest.mark.asyncio
+    async def test_process_single_item(self, queue_manager, mock_runner, storage):
+        """Test processing a single item."""
+        await queue_manager.enqueue(prompt="Test", group_name="main")
+
+        processed = await queue_manager.process_batch()
+        assert processed == 1
+
+        # Verify runner was called
+        mock_runner.run_prompt.assert_called_once()
+        call_kwargs = mock_runner.run_prompt.call_args.kwargs
+        assert call_kwargs["group_name"] == "main"
+        assert call_kwargs["prompt"] == "Test"
+
+    @pytest.mark.asyncio
+    async def test_process_item_with_context(self, queue_manager, mock_runner):
+        """Test that context is included in prompt."""
+        await queue_manager.enqueue(
+            prompt="Analyze this",
+            group_name="main",
+            context={"data": "test_data", "step": 2},
+        )
+
+        await queue_manager.process_batch()
+
+        call_kwargs = mock_runner.run_prompt.call_args.kwargs
+        prompt = call_kwargs["prompt"]
+        assert "Context from previous conversation:" in prompt
+        assert "data: test_data" in prompt
+        assert "step: 2" in prompt
+        assert "Analyze this" in prompt
+
+    @pytest.mark.asyncio
+    async def test_process_respects_max_dispatch(self, storage, mock_runner):
+        """Test that process_batch respects max_dispatch config."""
+        qm = QueueManager(
+            storage=storage,
+            runner=mock_runner,
+            config=QueueConfig(max_dispatch=2),
+        )
+
+        # Enqueue 5 items
+        for i in range(5):
+            await qm.enqueue(prompt=f"Item {i}", group_name="main")
+
+        processed = await qm.process_batch()
+        assert processed == 2
+        assert mock_runner.run_prompt.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_process_disabled_queue(self, storage, mock_runner):
+        """Test that disabled queue doesn't process items."""
+        qm = QueueManager(
+            storage=storage,
+            runner=mock_runner,
+            config=QueueConfig(enabled=False),
+        )
+
+        await qm.enqueue(prompt="Test", group_name="main")
+
+        processed = await qm.process_batch()
+        assert processed == 0
+        mock_runner.run_prompt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_successful_completion(self, queue_manager, storage):
+        """Test that successful items are marked completed."""
+        item_id = await queue_manager.enqueue(prompt="Test", group_name="main")
+
+        await queue_manager.process_batch()
+
+        item = storage.load_queue_item(item_id)
+        assert item.status == "completed"
+        assert item.result == "Test response"
+        assert item.processed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_process_failed_item(self, storage, mock_runner):
+        """Test that failed items are marked as failed."""
+        mock_runner.run_prompt = AsyncMock(
+            return_value=ConversationResult(
+                success=False, message="Failed", error="Something went wrong"
+            )
+        )
+        qm = QueueManager(storage=storage, runner=mock_runner, config=QueueConfig())
+
+        item_id = await qm.enqueue(prompt="Test", group_name="main")
+        await qm.process_batch()
+
+        item = storage.load_queue_item(item_id)
+        assert item.status == "failed"
+        assert item.error == "Something went wrong"
+
+    @pytest.mark.asyncio
+    async def test_process_exception(self, storage, mock_runner):
+        """Test that exceptions are caught and item is marked failed."""
+        mock_runner.run_prompt = AsyncMock(side_effect=Exception("Unexpected error"))
+        qm = QueueManager(storage=storage, runner=mock_runner, config=QueueConfig())
+
+        item_id = await qm.enqueue(prompt="Test", group_name="main")
+        await qm.process_batch()
+
+        item = storage.load_queue_item(item_id)
+        assert item.status == "failed"
+        assert "Unexpected error" in item.error
+
+
+class TestHelperMethods:
+    """Tests for helper methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_stats(self, queue_manager, storage):
+        """Test getting queue statistics."""
+        # Enqueue and process some items
+        await queue_manager.enqueue(prompt="Item 1", group_name="main")
+        await queue_manager.enqueue(prompt="Item 2", group_name="main")
+        await queue_manager.enqueue(prompt="Item 3", group_name="main")
+
+        # Process one
+        storage.dequeue(max_items=1)
+        storage.complete_queue_item(
+            storage.list_queue(status="processing")[0].id, "Done"
+        )
+
+        stats = queue_manager.get_stats()
+        assert stats.get("pending") == 2
+        assert stats.get("completed") == 1
+
+    @pytest.mark.asyncio
+    async def test_list_pending(self, queue_manager):
+        """Test listing pending items."""
+        await queue_manager.enqueue(prompt="Item 1", group_name="main")
+        await queue_manager.enqueue(prompt="Item 2", group_name="main")
+
+        pending = queue_manager.list_pending()
+        assert len(pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_clear_completed(self, queue_manager, storage):
+        """Test clearing completed items."""
+        item_id = await queue_manager.enqueue(prompt="Item 1", group_name="main")
+        await queue_manager.enqueue(prompt="Item 2", group_name="main")
+
+        # Complete one
+        storage.complete_queue_item(item_id, "Done")
+
+        deleted = queue_manager.clear_completed()
+        assert deleted == 1
+
+        # Pending item should still exist
+        pending = queue_manager.list_pending()
+        assert len(pending) == 1
+
+
+class TestBuildPromptWithContext:
+    """Tests for _build_prompt_with_context."""
+
+    def test_no_context(self, queue_manager, storage):
+        """Test prompt without context."""
+        from openpaws.storage import QueueItem
+
+        item = QueueItem.create(prompt="Test prompt", group_name="main")
+        result = queue_manager._build_prompt_with_context(item)
+        assert result == "Test prompt"
+
+    def test_with_context(self, queue_manager, storage):
+        """Test prompt with context."""
+        from openpaws.storage import QueueItem
+
+        item = QueueItem.create(
+            prompt="Test prompt", group_name="main", context={"key1": "val1", "key2": "val2"}
+        )
+        result = queue_manager._build_prompt_with_context(item)
+        assert "Context from previous conversation:" in result
+        assert "- key1: val1" in result
+        assert "- key2: val2" in result
+        assert "Test prompt" in result

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from openpaws.config import QueueConfig
+from openpaws.config import GroupConfig, QueueConfig
 from openpaws.queue_manager import QueueManager
 from openpaws.runner import ConversationResult
 from openpaws.storage import Storage
@@ -19,11 +19,16 @@ def storage(tmp_path):
 
 @pytest.fixture
 def mock_runner():
-    """Create a mock runner."""
+    """Create a mock runner with config containing 'main' group."""
     runner = MagicMock()
     runner.run_prompt = AsyncMock(
         return_value=ConversationResult(success=True, message="Test response")
     )
+    # Add config with groups for validation
+    runner.config = MagicMock()
+    runner.config.groups = {
+        "main": GroupConfig(name="main", channel="test", chat_id="123")
+    }
     return runner
 
 
@@ -93,6 +98,15 @@ class TestEnqueue:
         item = storage.load_queue_item(item_id)
         assert item.workflow_id == "workflow-123"
         assert item.parent_conversation_id == "parent-456"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_invalid_group(self, queue_manager):
+        """Test enqueueing with a group that doesn't exist."""
+        with pytest.raises(ValueError, match="not found"):
+            await queue_manager.enqueue(
+                prompt="Test prompt",
+                group_name="nonexistent",
+            )
 
 
 class TestProcessBatch:
@@ -274,7 +288,9 @@ class TestBuildPromptWithContext:
         from openpaws.storage import QueueItem
 
         item = QueueItem.create(
-            prompt="Test prompt", group_name="main", context={"key1": "val1", "key2": "val2"}
+            prompt="Test prompt",
+            group_name="main",
+            context={"key1": "val1", "key2": "val2"},
         )
         result = queue_manager._build_prompt_with_context(item)
         assert "Context from previous conversation:" in result

--- a/tests/test_queue_next_tool.py
+++ b/tests/test_queue_next_tool.py
@@ -18,6 +18,7 @@ class TestCallbackRegistry:
 
     def test_register_and_get_callback(self):
         """Test registering and retrieving a callback."""
+
         async def callback(prompt, group_name, context, priority, workflow_id):
             return "test-id"
 
@@ -29,6 +30,7 @@ class TestCallbackRegistry:
 
     def test_unregister_callback(self):
         """Test unregistering a callback."""
+
         async def callback(prompt, group_name, context, priority, workflow_id):
             return "test-id"
 
@@ -130,6 +132,7 @@ class TestQueueNextExecutor:
     @pytest.mark.asyncio
     async def test_executor_with_callback(self):
         """Test executor with registered callback."""
+
         async def callback(prompt, group_name, context, priority, workflow_id):
             return f"item-{prompt[:4]}"
 

--- a/tests/test_queue_next_tool.py
+++ b/tests/test_queue_next_tool.py
@@ -1,0 +1,181 @@
+"""Tests for QueueNextTool."""
+
+import pytest
+
+from openpaws.tools.queue_next import (
+    QueueNextAction,
+    QueueNextExecutor,
+    QueueNextObservation,
+    QueueNextTool,
+    get_queue_callback,
+    register_queue_callback,
+    unregister_queue_callback,
+)
+
+
+class TestCallbackRegistry:
+    """Tests for callback registration."""
+
+    def test_register_and_get_callback(self):
+        """Test registering and retrieving a callback."""
+        async def callback(prompt, group_name, context, priority, workflow_id):
+            return "test-id"
+
+        register_queue_callback("conv-1", callback)
+        assert get_queue_callback("conv-1") is callback
+
+        # Cleanup
+        unregister_queue_callback("conv-1")
+
+    def test_unregister_callback(self):
+        """Test unregistering a callback."""
+        async def callback(prompt, group_name, context, priority, workflow_id):
+            return "test-id"
+
+        register_queue_callback("conv-2", callback)
+        unregister_queue_callback("conv-2")
+        assert get_queue_callback("conv-2") is None
+
+    def test_get_nonexistent_callback(self):
+        """Test getting a callback that doesn't exist."""
+        assert get_queue_callback("nonexistent") is None
+
+    def test_unregister_nonexistent_callback(self):
+        """Test unregistering a callback that doesn't exist (should not raise)."""
+        unregister_queue_callback("nonexistent")  # Should not raise
+
+
+class TestQueueNextAction:
+    """Tests for QueueNextAction."""
+
+    def test_action_creation(self):
+        """Test creating an action with required fields."""
+        action = QueueNextAction(prompt="Test prompt", group_name="main")
+        assert action.prompt == "Test prompt"
+        assert action.group_name == "main"
+        assert action.context is None
+        assert action.priority == 0
+        assert action.workflow_id is None
+
+    def test_action_with_all_fields(self):
+        """Test creating an action with all fields."""
+        action = QueueNextAction(
+            prompt="Test prompt",
+            group_name="main",
+            context={"key": "value"},
+            priority=10,
+            workflow_id="wf-123",
+        )
+        assert action.context == {"key": "value"}
+        assert action.priority == 10
+        assert action.workflow_id == "wf-123"
+
+    def test_action_visualize(self):
+        """Test the visualize property."""
+        action = QueueNextAction(prompt="Test prompt", group_name="main")
+        viz = action.visualize
+        assert "Queuing follow-up" in viz.plain
+        assert "Test prompt" in viz.plain
+
+    def test_action_visualize_truncates_long_prompt(self):
+        """Test that long prompts are truncated in visualization."""
+        long_prompt = "x" * 100
+        action = QueueNextAction(prompt=long_prompt, group_name="main")
+        viz = action.visualize
+        assert "..." in viz.plain
+        assert len(action.prompt) == 100  # Original still full
+
+
+class TestQueueNextObservation:
+    """Tests for QueueNextObservation."""
+
+    def test_observation_success(self):
+        """Test successful observation."""
+        obs = QueueNextObservation(queued=True, item_id="abc123def456")
+        assert obs.queued is True
+        assert obs.item_id == "abc123def456"
+
+    def test_observation_failure(self):
+        """Test failure observation."""
+        obs = QueueNextObservation(queued=False, item_id=None)
+        assert obs.queued is False
+        assert obs.item_id is None
+
+    def test_observation_visualize_success(self):
+        """Test success visualization."""
+        obs = QueueNextObservation(queued=True, item_id="abc123def456")
+        viz = obs.visualize
+        assert "queued" in viz.plain.lower()
+        assert "abc123de" in viz.plain  # Shows truncated ID
+
+    def test_observation_visualize_failure(self):
+        """Test failure visualization."""
+        obs = QueueNextObservation(queued=False, item_id=None)
+        viz = obs.visualize
+        assert "Failed" in viz.plain
+
+
+class TestQueueNextExecutor:
+    """Tests for QueueNextExecutor."""
+
+    def test_executor_no_callback(self):
+        """Test executor when no callback is registered."""
+        executor = QueueNextExecutor()
+        action = QueueNextAction(prompt="Test", group_name="main")
+
+        obs = executor(action, conversation=None)
+        assert obs.queued is False
+        assert "not available" in obs.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_executor_with_callback(self):
+        """Test executor with registered callback."""
+        async def callback(prompt, group_name, context, priority, workflow_id):
+            return f"item-{prompt[:4]}"
+
+        # Create a mock conversation with state
+        class MockState:
+            id = "test-conv-id"
+
+        class MockConversation:
+            state = MockState()
+
+        register_queue_callback("test-conv-id", callback)
+        try:
+            executor = QueueNextExecutor()
+            action = QueueNextAction(prompt="Test prompt", group_name="main")
+
+            obs = executor(action, conversation=MockConversation())
+            assert obs.queued is True
+            assert obs.item_id == "item-Test"
+        finally:
+            unregister_queue_callback("test-conv-id")
+
+
+class TestQueueNextTool:
+    """Tests for QueueNextTool creation."""
+
+    def test_tool_create(self):
+        """Test creating the tool."""
+        tools = QueueNextTool.create()
+        assert len(tools) == 1
+        assert isinstance(tools[0], QueueNextTool)
+
+    def test_tool_annotations(self):
+        """Test tool annotations."""
+        tools = QueueNextTool.create()
+        tool = tools[0]
+        assert tool.annotations.readOnlyHint is False
+        assert tool.annotations.destructiveHint is False
+
+    def test_tool_description(self):
+        """Test tool has a description."""
+        tools = QueueNextTool.create()
+        tool = tools[0]
+        assert "Queue" in tool.description
+        assert "follow-up" in tool.description
+
+    def test_tool_create_with_invalid_params(self):
+        """Test that invalid params raise ValueError."""
+        with pytest.raises(ValueError):
+            QueueNextTool.create(invalid_param="test")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 
-from openpaws.storage import SessionState, Storage, TaskState
+from openpaws.storage import QueueItem, SessionState, Storage, TaskState
 
 
 @pytest.fixture
@@ -248,3 +248,253 @@ class TestStorageInitialization:
         monkeypatch.setenv("OPENPAWS_DIR", str(tmp_path))
         storage = Storage()
         assert storage.db_path == tmp_path / "state.db"
+
+    def test_creates_queue_table(self, tmp_path):
+        """Test that storage creates the queue table."""
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        Storage(db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cursor.fetchall()}
+        conn.close()
+
+        assert "queue" in tables
+
+
+class TestQueuePersistence:
+    """Tests for queue item persistence."""
+
+    def test_create_queue_item(self):
+        """Test QueueItem.create factory method."""
+        item = QueueItem.create(
+            prompt="Test prompt",
+            group_name="main",
+            context={"key": "value"},
+            priority=5,
+            workflow_id="workflow-123",
+        )
+        assert item.id is not None
+        assert item.prompt == "Test prompt"
+        assert item.group_name == "main"
+        assert item.context == {"key": "value"}
+        assert item.priority == 5
+        assert item.workflow_id == "workflow-123"
+        assert item.status == "pending"
+        assert item.created_at is not None
+
+    def test_enqueue_and_load(self, storage):
+        """Test enqueueing and loading a queue item."""
+        item = QueueItem.create(
+            prompt="Test prompt",
+            group_name="main",
+            context={"step": 1},
+            priority=1,
+            parent_conversation_id="parent-123",
+            workflow_id="workflow-456",
+        )
+        returned_id = storage.enqueue(item)
+        assert returned_id == item.id
+
+        loaded = storage.load_queue_item(item.id)
+        assert loaded is not None
+        assert loaded.id == item.id
+        assert loaded.prompt == "Test prompt"
+        assert loaded.group_name == "main"
+        assert loaded.context == {"step": 1}
+        assert loaded.priority == 1
+        assert loaded.status == "pending"
+        assert loaded.parent_conversation_id == "parent-123"
+        assert loaded.workflow_id == "workflow-456"
+
+    def test_load_nonexistent_queue_item(self, storage):
+        """Test loading a queue item that doesn't exist."""
+        loaded = storage.load_queue_item("nonexistent")
+        assert loaded is None
+
+    def test_dequeue_single_item(self, storage):
+        """Test dequeuing a single item."""
+        item = QueueItem.create(prompt="Test", group_name="main")
+        storage.enqueue(item)
+
+        dequeued = storage.dequeue(max_items=1)
+        assert len(dequeued) == 1
+        assert dequeued[0].id == item.id
+        assert dequeued[0].status == "processing"
+
+        # Verify status is persisted
+        loaded = storage.load_queue_item(item.id)
+        assert loaded.status == "processing"
+
+    def test_dequeue_respects_priority(self, storage):
+        """Test that dequeue returns items in priority order."""
+        low = QueueItem.create(prompt="Low", group_name="main", priority=0)
+        high = QueueItem.create(prompt="High", group_name="main", priority=10)
+        medium = QueueItem.create(prompt="Medium", group_name="main", priority=5)
+
+        storage.enqueue(low)
+        storage.enqueue(high)
+        storage.enqueue(medium)
+
+        dequeued = storage.dequeue(max_items=3)
+        assert len(dequeued) == 3
+        assert dequeued[0].id == high.id
+        assert dequeued[1].id == medium.id
+        assert dequeued[2].id == low.id
+
+    def test_dequeue_respects_max_items(self, storage):
+        """Test that dequeue respects the max_items limit."""
+        for i in range(5):
+            storage.enqueue(QueueItem.create(prompt=f"Item {i}", group_name="main"))
+
+        dequeued = storage.dequeue(max_items=2)
+        assert len(dequeued) == 2
+
+    def test_dequeue_only_pending_items(self, storage):
+        """Test that dequeue only returns pending items."""
+        pending = QueueItem.create(prompt="Pending", group_name="main")
+        storage.enqueue(pending)
+
+        # First dequeue marks as processing
+        storage.dequeue(max_items=1)
+
+        # Second dequeue should return empty
+        dequeued = storage.dequeue(max_items=1)
+        assert len(dequeued) == 0
+
+    def test_complete_queue_item(self, storage):
+        """Test marking a queue item as completed."""
+        item = QueueItem.create(prompt="Test", group_name="main")
+        storage.enqueue(item)
+
+        result = storage.complete_queue_item(item.id, "Success result")
+        assert result is True
+
+        loaded = storage.load_queue_item(item.id)
+        assert loaded.status == "completed"
+        assert loaded.result == "Success result"
+        assert loaded.processed_at is not None
+
+    def test_complete_nonexistent_item(self, storage):
+        """Test completing a queue item that doesn't exist."""
+        result = storage.complete_queue_item("nonexistent", "Result")
+        assert result is False
+
+    def test_fail_queue_item(self, storage):
+        """Test marking a queue item as failed."""
+        item = QueueItem.create(prompt="Test", group_name="main")
+        storage.enqueue(item)
+
+        result = storage.fail_queue_item(item.id, "Error message")
+        assert result is True
+
+        loaded = storage.load_queue_item(item.id)
+        assert loaded.status == "failed"
+        assert loaded.error == "Error message"
+        assert loaded.processed_at is not None
+
+    def test_fail_nonexistent_item(self, storage):
+        """Test failing a queue item that doesn't exist."""
+        result = storage.fail_queue_item("nonexistent", "Error")
+        assert result is False
+
+    def test_list_queue_all(self, storage):
+        """Test listing all queue items."""
+        item1 = QueueItem.create(prompt="Item 1", group_name="main")
+        item2 = QueueItem.create(prompt="Item 2", group_name="main")
+        storage.enqueue(item1)
+        storage.enqueue(item2)
+
+        items = storage.list_queue()
+        assert len(items) == 2
+
+    def test_list_queue_by_status(self, storage):
+        """Test listing queue items filtered by status."""
+        item1 = QueueItem.create(prompt="Item 1", group_name="main")
+        item2 = QueueItem.create(prompt="Item 2", group_name="main")
+        storage.enqueue(item1)
+        storage.enqueue(item2)
+
+        # Complete one item
+        storage.complete_queue_item(item1.id, "Done")
+
+        pending = storage.list_queue(status="pending")
+        assert len(pending) == 1
+        assert pending[0].id == item2.id
+
+        completed = storage.list_queue(status="completed")
+        assert len(completed) == 1
+        assert completed[0].id == item1.id
+
+    def test_clear_queue_all(self, storage):
+        """Test clearing all queue items."""
+        for i in range(3):
+            storage.enqueue(QueueItem.create(prompt=f"Item {i}", group_name="main"))
+
+        deleted = storage.clear_queue()
+        assert deleted == 3
+
+        items = storage.list_queue()
+        assert len(items) == 0
+
+    def test_clear_queue_by_status(self, storage):
+        """Test clearing queue items by status."""
+        item1 = QueueItem.create(prompt="Item 1", group_name="main")
+        item2 = QueueItem.create(prompt="Item 2", group_name="main")
+        storage.enqueue(item1)
+        storage.enqueue(item2)
+
+        # Complete one item
+        storage.complete_queue_item(item1.id, "Done")
+
+        # Clear only completed items
+        deleted = storage.clear_queue(status="completed")
+        assert deleted == 1
+
+        # Pending item should still exist
+        items = storage.list_queue()
+        assert len(items) == 1
+        assert items[0].id == item2.id
+
+    def test_get_queue_stats(self, storage):
+        """Test getting queue statistics."""
+        item1 = QueueItem.create(prompt="Item 1", group_name="main")
+        item2 = QueueItem.create(prompt="Item 2", group_name="main")
+        item3 = QueueItem.create(prompt="Item 3", group_name="main")
+        storage.enqueue(item1)
+        storage.enqueue(item2)
+        storage.enqueue(item3)
+
+        # Complete one, fail one
+        storage.complete_queue_item(item1.id, "Done")
+        storage.fail_queue_item(item2.id, "Error")
+
+        stats = storage.get_queue_stats()
+        assert stats.get("pending") == 1
+        assert stats.get("completed") == 1
+        assert stats.get("failed") == 1
+
+    def test_queue_item_with_null_context(self, storage):
+        """Test queue item with no context."""
+        item = QueueItem.create(prompt="Test", group_name="main", context=None)
+        storage.enqueue(item)
+
+        loaded = storage.load_queue_item(item.id)
+        assert loaded.context is None
+
+    def test_queue_fifo_within_priority(self, storage):
+        """Test that items with same priority are FIFO ordered."""
+        import time
+
+        item1 = QueueItem.create(prompt="First", group_name="main", priority=5)
+        storage.enqueue(item1)
+        time.sleep(0.01)  # Small delay to ensure different timestamps
+
+        item2 = QueueItem.create(prompt="Second", group_name="main", priority=5)
+        storage.enqueue(item2)
+
+        dequeued = storage.dequeue(max_items=2)
+        assert dequeued[0].id == item1.id
+        assert dequeued[1].id == item2.id


### PR DESCRIPTION
## Summary

Implements queue-based dispatch for multi-conversation orchestration (closes #5).

This enables agents to queue follow-up conversations that are processed by a heartbeat dispatcher at configurable intervals, allowing for:
- Multi-step workflows that span multiple conversations
- Controlled pacing to avoid API rate limits
- Priority-based processing
- Context preservation between conversations

## Changes

### New Files
- `src/openpaws/queue_manager.py` - Queue coordination layer
- `src/openpaws/tools/queue_next.py` - Agent tool for queuing
- `tests/test_queue_manager.py` - 17 queue manager tests
- `tests/test_queue_next_tool.py` - 18 tool tests

### Modified Files
- `src/openpaws/storage.py` - QueueItem dataclass, queue table, CRUD methods
- `src/openpaws/config.py` - QueueConfig dataclass
- `src/openpaws/daemon.py` - Heartbeat loop integration
- `src/openpaws/runner.py` - Queue callback registration
- `src/openpaws/cli.py` - Queue CLI commands
- `AGENTS.md` - Documentation updates

## Configuration

```yaml
queue:
  enabled: true             # Enable queue dispatch (default: true)
  heartbeat_interval: 300   # Seconds between processing (default: 300)
  max_dispatch: 5           # Max items per heartbeat (default: 5)
```

## CLI Commands

```bash
openpaws queue list              # List queued conversations
openpaws queue stats             # Show statistics by status
openpaws queue add "prompt" -g main  # Manually add item
openpaws queue clear -s completed    # Clear by status
```

## Tests

All 523 tests passing (35 new queue-related tests).

---
_This PR was created by an AI assistant (OpenHands) on behalf of jpshackelford._